### PR TITLE
Improving federation reliability.

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -68,8 +68,9 @@ module TestHelpers
       Fiber.yield
       res = yield
       return res if res
-      raise "Execuction expired" if Time.monotonic - sec > timeout
+      break if Time.monotonic - sec > timeout
     end
+    raise "Execuction expired"
   end
 
   def test_headers(headers = nil)

--- a/spec/upstream_spec.cr
+++ b/spec/upstream_spec.cr
@@ -9,9 +9,33 @@ module UpstreamSpecHelpers
     {x, q2}
   end
 
-  def self.cleanup
+  def self.cleanup(upstream)
+    links = upstream.links
     s.vhosts["/"].delete_queue("federation_q1")
     s.vhosts["/"].delete_queue("federation_q2")
+    wait_for { links.all?(&.state.terminated?) }
+  end
+
+  def self.setup_ex_federation(upstream_name)
+    upstream_vhost = s.vhosts.create("upstream")
+    downstream_vhost = s.vhosts.create("downstream")
+    upstream = AvalancheMQ::Federation::Upstream.new(downstream_vhost, upstream_name,
+      "#{AMQP_BASE_URL}/upstream", "upstream_ex")
+    upstream.ack_timeout = 1.milliseconds
+    downstream_vhost.upstreams.not_nil!.add(upstream)
+    definitions = {"federation-upstream" => JSON::Any.new(upstream_name)} of String => JSON::Any
+    downstream_vhost.add_policy("FE", /downstream_ex/, AvalancheMQ::Policy::Target::Exchanges,
+      definitions, 12_i8)
+    {upstream, upstream_vhost, downstream_vhost}
+  end
+
+  def self.cleanup_ex_federation
+    v1 = s.vhosts["downstream"]
+    v2 = s.vhosts["upstream"]
+    s.vhosts.delete("downstream")
+    s.vhosts.delete("upstream")
+
+    wait_for { !(Dir.exists?(v1.data_dir) || Dir.exists?(v2.data_dir)) }
   end
 end
 
@@ -34,8 +58,7 @@ describe AvalancheMQ::Federation::Upstream do
       vhost.queues["federation_q1"].message_count.should eq 0
     end
   ensure
-    UpstreamSpecHelpers.cleanup
-    upstream.not_nil!.close(sync: true)
+    UpstreamSpecHelpers.cleanup(upstream.not_nil!)
   end
 
   it "should not federate queue if no downstream consumer" do
@@ -46,13 +69,12 @@ describe AvalancheMQ::Federation::Upstream do
       x = UpstreamSpecHelpers.setup_qs(ch).first
       x.publish "federate me", "federation_q1"
       link = upstream.link(vhost.queues["federation_q2"])
-      wait_for { link.running? }
+      wait_for { link.state.running? }
       vhost.queues["federation_q1"].message_count.should eq 1
       vhost.queues["federation_q2"].message_count.should eq 0
     end
   ensure
-    upstream.not_nil!.close(sync: true)
-    UpstreamSpecHelpers.cleanup
+    UpstreamSpecHelpers.cleanup(upstream.not_nil!)
   end
 
   it "should federate queue with ack mode no-ack" do
@@ -71,8 +93,7 @@ describe AvalancheMQ::Federation::Upstream do
       vhost.queues["federation_q1"].message_count.should eq 0
     end
   ensure
-    UpstreamSpecHelpers.cleanup
-    upstream.not_nil!.close(sync: true)
+    UpstreamSpecHelpers.cleanup(upstream.not_nil!)
   end
 
   it "should federate queue with ack mode on-publish" do
@@ -91,8 +112,7 @@ describe AvalancheMQ::Federation::Upstream do
       vhost.queues["federation_q1"].message_count.should eq 0
     end
   ensure
-    UpstreamSpecHelpers.cleanup
-    upstream.not_nil!.close(sync: true)
+    UpstreamSpecHelpers.cleanup(upstream.not_nil!)
   end
 
   it "should resume federation after downstream reconnects" do
@@ -122,8 +142,7 @@ describe AvalancheMQ::Federation::Upstream do
       vhost.queues["federation_q1"].message_count.should eq 0
     end
   ensure
-    UpstreamSpecHelpers.cleanup
-    upstream.not_nil!.close(sync: true)
+    UpstreamSpecHelpers.cleanup(upstream.not_nil!)
   end
 
   it "should federate exchange" do
@@ -135,7 +154,7 @@ describe AvalancheMQ::Federation::Upstream do
       downstream_q = ch.queue("downstream_q")
       downstream_q.bind(downstream_ex.name, "#")
       link = upstream.link(vhost.exchanges[downstream_ex.name])
-      wait_for { link.running? }
+      wait_for { link.state.running? }
       upstream_ex = ch.exchange("upstream_ex", "topic", passive: true)
       upstream_ex.publish "federate me", "rk"
       msgs = [] of AMQP::Client::Message
@@ -145,9 +164,9 @@ describe AvalancheMQ::Federation::Upstream do
     end
   ensure
     s.vhosts["/"].delete_queue("downstream_q")
-    s.vhosts["/"].delete_queue("downstream_ex")
-    s.vhosts["/"].delete_queue("upstream_ex")
-    upstream.try &.close(sync: true)
+    s.vhosts["/"].delete_exchange("downstream_ex")
+    s.vhosts["/"].delete_exchange("upstream_ex")
+    wait_for { upstream.not_nil!.links.all?(&.state.terminated?) }
   end
 
   it "should keep message properties" do
@@ -164,21 +183,11 @@ describe AvalancheMQ::Federation::Upstream do
       msgs.first.properties.content_type.should eq "application/json"
     end
   ensure
-    UpstreamSpecHelpers.cleanup
-    upstream.not_nil!.close(sync: true)
+    UpstreamSpecHelpers.cleanup(upstream.not_nil!)
   end
 
   it "should federate exchange even with no downstream consumer" do
-    upstream_vhost = s.vhosts.create("upstream")
-    downstream_vhost = s.vhosts.create("downstream")
-    upstream_name = "ef test upstream wo downstream"
-    upstream = AvalancheMQ::Federation::Upstream.new(downstream_vhost, upstream_name,
-      "#{AMQP_BASE_URL}/upstream", "upstream_ex")
-    upstream.ack_timeout = 1.milliseconds
-    downstream_vhost.upstreams.not_nil!.add(upstream)
-    definitions = {"federation-upstream" => JSON::Any.new(upstream_name)} of String => JSON::Any
-    downstream_vhost.add_policy("FE", /downstream_ex/, AvalancheMQ::Policy::Target::Exchanges,
-      definitions, 12_i8)
+    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_ex_federation("ef test upstream wo downstream")
 
     with_channel(vhost: "upstream") do |upstream_ch|
       with_channel(vhost: "downstream") do |downstream_ch|
@@ -186,7 +195,7 @@ describe AvalancheMQ::Federation::Upstream do
         downstream_ch.exchange("downstream_ex", "topic")
         wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
         # Assert setup is correct
-        wait_for { upstream.links.first?.try(&.running?) }
+        wait_for { upstream.links.first?.try &.state.running? }
         downstream_q = downstream_ch.queue("downstream_q")
         downstream_q.bind("downstream_ex", "#")
         upstream_ex.publish_confirm "federate me", "rk"
@@ -198,11 +207,45 @@ describe AvalancheMQ::Federation::Upstream do
         msgs.first.not_nil!.body_io.to_s.should eq("federate me")
       end
     end
-    sleep 0.01 # Wait for acks
     upstream_vhost.queues.each_value.all?(&.empty?).should be_true
   ensure
-    upstream.try &.close(sync: true) # Avoid error log for missing vhost
-    s.vhosts.delete("downstream")
-    s.vhosts.delete("upstream")
+    UpstreamSpecHelpers.cleanup_ex_federation
+  end
+
+  it "should continue after upstream restart" do
+    upstream, upstream_vhost, downstream_vhost = UpstreamSpecHelpers.setup_ex_federation("ef test upstream restart")
+
+    with_channel(vhost: "upstream") do |upstream_ch|
+      with_channel(vhost: "downstream") do |downstream_ch|
+        upstream_ex = upstream_ch.exchange("upstream_ex", "topic")
+        downstream_ch.exchange("downstream_ex", "topic")
+        wait_for { downstream_vhost.exchanges["downstream_ex"].policy.try(&.name) == "FE" }
+        # Assert setup is correct
+        wait_for { upstream.links.first?.try &.state.running? }
+        downstream_q = downstream_ch.queue("downstream_q")
+        downstream_q.bind("downstream_ex", "#")
+        msgs = [] of AMQP::Client::Message
+        downstream_q.subscribe do |msg|
+          msgs << msg
+        end
+        upstream_ex.publish_confirm "federate me", "rk1"
+        wait_for { msgs.size == 1 }
+        upstream_vhost.connections.each do |conn|
+          next unless conn.client_name.starts_with?("Federation link")
+          conn.close
+        end
+        wait_for { upstream.links.first?.try { |l| l.state.stopped? || l.state.starting? } }
+        upstream_ex.publish_confirm "federate me", "rk2"
+        # Should reconnect
+        wait_for { upstream.links.first?.try(&.state.running?) }
+        upstream_ex.publish_confirm "federate me", "rk3"
+        wait_for {
+          msgs.size == 3
+        }
+      end
+    end
+    upstream_vhost.queues.each_value.all?(&.empty?).should be_true
+  ensure
+    UpstreamSpecHelpers.cleanup_ex_federation
   end
 end

--- a/src/avalanchemq/client/channel.cr
+++ b/src/avalanchemq/client/channel.cr
@@ -291,6 +291,9 @@ module AvalancheMQ
           @log.debug { "Channel is closed so is not sending #{frame.inspect}" }
           return false
         end
+        # Make sure publishes are confirmed before we deliver
+        # can happend if the vhost spawned fsync fiber has not execed yet
+        @client.vhost.send_publish_confirms
         @client.deliver(frame, msg) || return false
         if redelivered
           @redeliver_count += 1

--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -80,6 +80,11 @@ module AvalancheMQ
       end
     end
 
+    # Returns client provided connection name if set, else server generated name
+    def client_name
+      @client_properties["connection_name"]?.try(&.as(String)) || @name
+    end
+
     def channel_name_prefix
       @remote_address.to_s
     end

--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -419,6 +419,7 @@ module AvalancheMQ
     def close(reason = nil)
       reason ||= "Connection closed"
       @log.info { "Closing, #{reason}" }
+      @vhost.fsync
       close_frame = AMQP::Frame::Connection::Close.new(320_u16, reason.to_s, 0_u16, 0_u16)
       send(close_frame) || cleanup
       @running = false

--- a/src/avalanchemq/exchange/consistent_hash.cr
+++ b/src/avalanchemq/exchange/consistent_hash.cr
@@ -19,8 +19,8 @@ module AvalancheMQ
       return "" if headers.nil?
       case value = headers[hash_on.as(String)]?
       when String then value.as(String)
-      when Nil then ""
-      else raise Error::PreconditionFailed.new("Routing header must be string")
+      when Nil    then ""
+      else             raise Error::PreconditionFailed.new("Routing header must be string")
       end
     end
 

--- a/src/avalanchemq/federation/upstream.cr
+++ b/src/avalanchemq/federation/upstream.cr
@@ -90,14 +90,8 @@ module AvalancheMQ
         link
       end
 
-      def close(sync = false)
+      def close
         links.each(&.terminate)
-        if sync
-          loop do
-            break if links.all?(&.terminated?)
-            Fiber.yield
-          end
-        end
         @ex_links.clear
         @q_links.clear
       end

--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -89,13 +89,17 @@ module AvalancheMQ
         @queues_to_fsync.each &.fsync_enq
         @queues_to_fsync.clear
       end
+      send_publish_confirms
+      @fsync = false
+    end
+
+    def send_publish_confirms
       @awaiting_confirm_lock.synchronize do
         @log.debug { "send confirm to #{@awaiting_confirm.size} channels" }
         @awaiting_confirm.each do |ch|
           ch.confirm_ack(multiple: true)
         end
         @awaiting_confirm.clear
-        @fsync = false
       end
     end
 

--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -21,7 +21,7 @@ module AvalancheMQ
     include SortableJSON
 
     getter name, exchanges, queues, log, data_dir, policies, parameters,
-      log, shovels, direct_reply_channels, upstreams, default_user,
+      log, shovels, direct_reply_channels, default_user,
       connections, dir
     property? flow = true
     property? dirty = false
@@ -439,22 +439,22 @@ module AvalancheMQ
       @parameters.delete({component_name, parameter_name})
       case component_name
       when SHOVEL
-        @shovels.not_nil!.delete(parameter_name)
+        shovels.delete(parameter_name)
       when FEDERATION_UPSTREAM
-        @upstreams.not_nil!.delete_upstream(parameter_name)
+        upstreams.delete_upstream(parameter_name)
       when FEDERATION_UPSTREAM_SET
-        @upstreams.not_nil!.delete_upstream_set(parameter_name)
+        upstreams.delete_upstream_set(parameter_name)
       else
         @log.warn { "No action when deleting parameter #{component_name}" }
       end
     end
 
     def stop_shovels
-      @shovels.not_nil!.each_value &.terminate
+      shovels.each_value &.terminate
     end
 
     def stop_upstream_links
-      @upstreams.not_nil!.stop_all
+      upstreams.stop_all
     end
 
     def close(seamless_restart = false, reason = "Broker shutdown")
@@ -519,11 +519,11 @@ module AvalancheMQ
       @parameters.apply(parameter) do |p|
         case p.component_name
         when SHOVEL
-          @shovels.not_nil!.create(p.parameter_name, p.value)
+          shovels.create(p.parameter_name, p.value)
         when FEDERATION_UPSTREAM
-          @upstreams.not_nil!.create_upstream(p.parameter_name, p.value)
+          upstreams.create_upstream(p.parameter_name, p.value)
         when FEDERATION_UPSTREAM_SET
-          @upstreams.not_nil!.create_upstream_set(p.parameter_name, p.value)
+          upstreams.create_upstream_set(p.parameter_name, p.value)
         else
           @log.warn { "No action when applying parameter #{p.component_name}" }
         end
@@ -843,6 +843,14 @@ module AvalancheMQ
         ConsistentHashExchange.new(vhost, name, durable, auto_delete, internal, arguments)
       else raise Error::ExchangeTypeError.new("Unknown exchange type #{type}")
       end
+    end
+
+    def upstreams
+      @upstreams.not_nil!
+    end
+
+    def shovels
+      @shovels.not_nil!
     end
   end
 end


### PR DESCRIPTION
Apart from refactoring links to keep references to the upstream and downstream connections this PR makes sure we send publish confirms before we deliver messages to consumers.