### PR TITLE
Only create/open a tmp file for Channel if needed

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -443,13 +443,15 @@ describe AvalancheMQ::Server do
     end
   end
 
-  it "can receive and deliver large messages" do
+  it "can receive and deliver multiple large messages" do
+    pmsg = "a" * 150_000
     with_channel do |ch|
-      pmsg1 = "a" * 8133
-      q = ch.queue
-      q.publish pmsg1
-      msg = q.get
-      msg.not_nil!.body_io.to_s.should eq pmsg1.to_s
+      2.times do
+        q = ch.queue
+        q.publish pmsg
+        msg = q.get
+        msg.not_nil!.body_io.to_s.should eq pmsg
+      end
     end
   end
 


### PR DESCRIPTION
The tmp file is only needed when the published message is spread out
over multiple frames.

This patch saves FDs and resources when many connections/channels are open.

Fixes #232