### PR TITLE
Be able to skip CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on: [push]
 jobs:
   lint:
     name: Lint
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
     container: crystallang/crystal:0.36.0
     continue-on-error: true
@@ -19,6 +24,11 @@ jobs:
 
   api-lint:
     name: Lint and build HTTP API documentation
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -31,6 +41,11 @@ jobs:
 
   spec:
     name: Spec
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-20.04
 
     steps:
@@ -56,6 +71,11 @@ jobs:
 
   compile:
     name: Compile AvalancheMQ
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build_docs:
     name: Build HTTP API documentation
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build_docs:
     name: Build HTTP API documentation
+    if: |
+      !(   contains(github.event.pull_request.title,  '[ci skip]')
+        || contains(github.event.pull_request.title,  '[skip ci]')
+        || contains(github.event.head_commit.message, '[ci skip]')
+        || contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Useful when only changing Markdown files, for example.

You can skip CI (and deb/rpm builds) including either `[ci skip]` or
`[skip ci]` in the commit message or the pull request title.

The `if` doesn't need to be on builds that have a `needs` on builds that
will be skipped, making some DRY possible.