### PR TITLE
Set the correct version in generated HTTP API docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Lint and build HTTP API documentation
         run: npm install

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Validate and build the documentation
         run: npm install

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Validate and build the documentation
         run: npm install

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .icr_*
 *.swp
 shard.override.yml
+/openapi/avalanchemq_version.yaml

--- a/build/npm_postinstall
+++ b/build/npm_postinstall
@@ -4,6 +4,9 @@ set -e
 
 [[ -d static/js/lib ]] && cp node_modules/chart.js/dist/Chart.bundle.min.js static/js/lib/chart.js
 
+echo "Creating file with AvalancheMQ version for OpenAPI spec..."
+./openapi/create_avalanchemq_version_yaml
+
 echo "Linting HTTP API documentation..."
 spectral lint openapi/openapi.yaml
 

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -6,15 +6,14 @@ It also copies it to `static/docs/index.html` so you can view the docs at [http:
 
 The dependencies:
 
+* `./create_avalanchemq_version_yaml` that creates `avalanchemq_version.yaml` (not in source control), needed when building the docs
 * [Spectral] is used to lint the documentation. To run it manually: `spectral lint openapi.yaml`
 * [ReDoc] is to build the documentation.
   To run it manually: `redoc-cli bundle openapi.yaml` (a file `redoc-static.html` will be created in your working directory)
 
 You can use the [ReDoc Docker image] to watch for updates so you can preview the documentation as you work on it. (Note the gotcha: the browser caches the YAML files even if they have changed, open dev console in the browser to mitigate.)
 
-Start it with:
-
-      ./redoc-serve-and-watch
+Start it with `./redoc-serve-and-watch`, then view the docs at [http://localhost:8080/](http://localhost:8080/).
 
 ## OpenAPI notes
 

--- a/openapi/create_avalanchemq_version_yaml
+++ b/openapi/create_avalanchemq_version_yaml
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+VERSION_FILE="$(dirname $0)/avalanchemq_version.yaml"
+
+echo "version: $(git describe --abbrev=0 | cut -c2-)" > $VERSION_FILE

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,8 @@
 ---
 openapi: 3.0.3
 info:
-  version: 1.0.0
+  version:
+    "$ref": "./avalanchemq_version.yaml#/version"
   title: AvalancheMQ Management HTTP API
   description: HTTP API to programmatically manage all aspects of AvalancheMQ.
   contact:

--- a/openapi/redoc-serve-and-watch
+++ b/openapi/redoc-serve-and-watch
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-set -x
+set -e
+
+./create_avalanchemq_version_yaml
+
+echo "View the docs at http://localhost:8080/"
 
 docker run -it --rm -p 8080:80 \
   -v $(pwd):/usr/share/nginx/html/swagger/ \


### PR DESCRIPTION
Get the version from git so we only need to bump it in one place.