### PR TITLE
Mark vhost as dirty when reading from disk on startup.

### DIFF
--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -667,6 +667,7 @@ module AvalancheMQ
         end
         segments[seg] = file
       end
+      @dirty = true unless was_empty
       segments
     end
 
@@ -677,8 +678,10 @@ module AvalancheMQ
       return if @closed
       referenced_sps = ReferencedSPs.new(@queues.size)
       loop do
-        sleep Config.instance.gc_segments_interval
-        next unless @dirty
+        unless @dirty
+          sleep Config.instance.gc_segments_interval
+          next
+        end
         break if @closed
         gc_log("collecting sps") do
           collect_sps(referenced_sps)


### PR DESCRIPTION
Marking the vhost as dirty when reading information from disk at startup will clear messages that are no longer referenced.

https://github.com/cloudamqp/avalanchemq/issues/201#issuecomment-791318428

Extends #202 