### PR TITLE
reuse buffers for restore_index!

### DIFF
--- a/src/avalanchemq/exchange/exchange.cr
+++ b/src/avalanchemq/exchange/exchange.cr
@@ -141,7 +141,7 @@ module AvalancheMQ
         next if ms <= 0
         args["x-message-ttl"] = ms
       end
-      @persistent_queue = PersistentExchangeQueue.new(@vhost, q_name, args)
+      @persistent_queue = QueueFactory.make_persistent_queue(@vhost, q_name, args)
       @vhost.queues[q_name] = @persistent_queue.not_nil!
     end
 
@@ -153,7 +153,7 @@ module AvalancheMQ
       raise "Exchange name too long" if q_name.size > MAX_NAME_LENGTH
       @log.debug { "Declaring delayed queue: #{name}" }
       arguments = Hash(String, AMQP::Field){"x-dead-letter-exchange" => @name}
-      @delayed_queue = DurableDelayedExchangeQueue.new(@vhost, q_name, false, false, arguments)
+      @delayed_queue = QueueFactory.make_delayed_exchange_queue(@vhost, q_name, arguments)
       @vhost.queues[q_name] = @delayed_queue.as(Queue)
     end
 

--- a/src/avalanchemq/queue/persistent_exchange_queue.cr
+++ b/src/avalanchemq/queue/persistent_exchange_queue.cr
@@ -4,9 +4,9 @@ module AvalancheMQ
   class PersistentExchangeQueue < DurableQueue
     @internal = true
 
-    def initialize(vhost : VHost, name : String, args)
+    def initialize(vhost : VHost, name : String, args, ready)
       args["x-overflow"] = "drop-head"
-      super(vhost, name, false, false, args)
+      super(vhost, name, false, false, args, ready)
     end
 
     def head(count : Int, &blk : SegmentPosition -> Nil)

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -50,7 +50,6 @@ module AvalancheMQ
     @message_available = Channel(Nil).new(1)
     @consumer_available = Channel(Nil).new(1)
     @refresh_ttl_timeout = Channel(Nil).new(1)
-    @ready = ReadyQueue.new
     @unacked = UnackQueue.new
     @paused = Channel(Nil).new(1)
 
@@ -68,7 +67,8 @@ module AvalancheMQ
 
     def initialize(@vhost : VHost, @name : String,
                    @exclusive = false, @auto_delete = false,
-                   @arguments = Hash(String, AMQP::Field).new)
+                   @arguments = Hash(String, AMQP::Field).new,
+                   @ready = ReadyQueue.new)
       @last_get_time = Time.monotonic
       @log = @vhost.log.dup
       @log.progname += " queue=#{@name}"

--- a/src/avalanchemq/queue/queue_factory.cr
+++ b/src/avalanchemq/queue/queue_factory.cr
@@ -4,28 +4,72 @@ require "./durable_queue"
 
 module AvalancheMQ
   class QueueFactory
+    @@locks = Hash(String, Mutex).new
+
     def self.make(vhost : VHost, frame : AMQP::Frame)
+      if prio_queue? frame
+        make(vhost, frame, Queue::PriorityReadyQueue.new)
+      else
+        make(vhost, frame, Queue::ReadyQueue.new)
+      end
+    end
+
+    def self.make(vhost : VHost, frame : AMQP::Frame, rq : Queue::ReadyQueue)
       if frame.durable
-        make_durable(vhost, frame)
+        if prio_queue? frame
+          DurablePriorityQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h, rq)
+        else
+          DurableQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h, rq)
+        end
       else
-        make_queue(vhost, frame)
+        if prio_queue? frame
+          PriorityQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h, rq)
+        else
+          Queue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h, rq)
+        end
       end
     end
 
-    private def self.make_durable(vhost, frame)
-      if prio_queue? frame
-        DurablePriorityQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h)
-      else
-        DurableQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h)
-      end
+    # When reading up durable queues we want to reuse the buffer to keep it faster
+    def self.make_buffered(vhost : VHost, frame : AMQP::Frame, ack_b : Array(SegmentPosition), ready_q : Queue::ReadyQueue)
+      index_dir = File.join(vhost.data_dir, Digest::SHA1.hexdigest frame.queue_name)
+      rq = if Dir.exists?(index_dir)
+             lock = @@locks[vhost.name] = @@locks[vhost.name]? || Mutex.new
+             lock.synchronize do
+               vhost.log.info "Restoring index queue=#{frame.queue_name}"
+               ack_b.clear
+               ready_q.clear
+               restore_index(index_dir, ack_b, ready_q)
+               vhost.log.info "Restored #{ready_q.size} messages queue=#{frame.queue_name}"
+               ready_q.dup
+             end
+           else
+             Queue::ReadyQueue.new
+           end
+      make(vhost, frame, rq)
     end
 
-    private def self.make_queue(vhost, frame)
-      if prio_queue? frame
-        PriorityQueue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h)
-      else
-        Queue.new(vhost, frame.queue_name, frame.exclusive, frame.auto_delete, frame.arguments.to_h)
-      end
+    def self.make_persistent_queue(vhost : VHost, name : String, args : Hash(String, AMQP::Field))
+      index_dir = File.join(vhost.data_dir, Digest::SHA1.hexdigest name)
+      rq = if Dir.exists?(index_dir)
+             restore_index(index_dir, Array(SegmentPosition).new, Queue::ReadyQueue.new)
+           else
+             Queue::ReadyQueue.new
+           end
+      PersistentExchangeQueue.new(vhost, name, args, rq)
+    end
+
+    def self.make_delayed_exchange_queue(vhost, name, arguments)
+      index_dir = File.join(vhost.data_dir, Digest::SHA1.hexdigest name)
+
+      rq_buf = Queue::ExpirationReadyQueue.new
+
+      rq = if Dir.exists?(index_dir)
+             restore_index(index_dir, Array(SegmentPosition).new, rq_buf)
+           else
+             rq_buf
+           end
+      DurableDelayedExchangeQueue.new(vhost, name, false, false, arguments, rq)
     end
 
     private def self.prio_queue?(frame)
@@ -35,6 +79,50 @@ module AvalancheMQ
           raise Error::PreconditionFailed.new("x-max-priority must be between 0 and 255")
         end
         true
+      end
+    end
+
+    private def self.restore_index(dir, acked, ready)
+      SchemaVersion.migrate(File.join(dir, "enq"), :index)
+      SchemaVersion.migrate(File.join(dir, "ack"), :index)
+      File.open(File.join(dir, "enq")) do |enq|
+        File.open(File.join(dir, "ack")) do |ack|
+          enq.buffer_size = Config.instance.file_buffer_size
+          ack.buffer_size = Config.instance.file_buffer_size
+          enq.advise(File::Advice::Sequential)
+          ack.advise(File::Advice::Sequential)
+          SchemaVersion.verify(enq, :index)
+          SchemaVersion.verify(ack, :index)
+
+          loop do
+            sp = SegmentPosition.from_io ack
+            if sp.zero?
+              File.open(ack.path, "W") do |f|
+                f.truncate(ack.pos - SegmentPosition::BYTESIZE)
+              end
+              break
+            end
+            acked << sp
+          rescue IO::EOFError
+            break
+          end
+          acked.try &.sort!
+
+          loop do
+            sp = SegmentPosition.from_io enq
+            if sp.zero?
+              File.open(enq.path, "W") do |f|
+                f.truncate(enq.pos - SegmentPosition::BYTESIZE)
+              end
+              break
+            end
+            next if acked.try { |a| a.bsearch { |asp| asp >= sp } == sp }
+            ready << sp
+          rescue IO::EOFError
+            break
+          end
+          ready
+        end
       end
     end
   end

--- a/src/avalanchemq/queue/ready.cr
+++ b/src/avalanchemq/queue/ready.cr
@@ -12,6 +12,10 @@ module AvalancheMQ
         @ready = Deque(SegmentPosition).new(@inital_capacity)
       end
 
+      def initialize(@ready : Deque(SegmentPosition))
+        @inital_capacity = @ready.capacity
+      end
+
       def includes?(sp)
         @ready.includes?(sp)
       end
@@ -185,6 +189,10 @@ module AvalancheMQ
         end
       end
 
+      def clear
+        @ready.clear
+      end
+
       def size
         @ready.size
       end
@@ -213,6 +221,10 @@ module AvalancheMQ
 
       def to_a
         @ready.to_a
+      end
+
+      def dup
+        self.class.new(@ready.dup)
       end
     end
 


### PR DESCRIPTION
This is an idea to fix the 
```
GC Warning: Repeated allocation of very large block (appr. size 18599936):
	May lead to memory leak and poor performance
```
warnings from `restore_index! `

It happens since each file is 44mb which results in allocating a lot of arrays and deque. 

The idea is to reuse one array and one ready queue for each vhost. 
The array that holds the acked SPs are just clear for each queue and the ReadyQueue we to a shallow copy of and set to `@ready` on the queue. Shallow copy is enough since the SP is a struct. 

Things to consider: 

* Size of `@ack_buffer` in VHost
* Size of `@ready_buffer` in VHost
* Not sure if `purge` is correct to use for `ReadyQueue` as it might allocate a new `Deque` if it has been resized 

Also, the code isn't very pretty, but not sure how to share the buffers otherwise. Putting them on the vhost I think is the best place, no locks needed. 

