### PR TITLE
Fiber#yield to allow read_loop to handle IO::Error.

### DIFF
--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -284,6 +284,7 @@ module AvalancheMQ
     rescue ex : IO::Error | OpenSSL::SSL::Error
       @log.debug { "Lost connection, while sending (#{ex.inspect})" }
       close_socket
+      Fiber.yield
       false
     rescue ex : AMQ::Protocol::Error::FrameEncode
       @log.warn { "Error encoding frame (#{ex.inspect})" }


### PR DESCRIPTION
In the event that an IO:Error occured during delivery we called Client#close_socket https://github.com/cloudamqp/avalanchemq/blob/14e6a82c7d687ee7cfd9f0ae067e1a57f4a2e064/src/avalanchemq/client/client.cr#L428-L434 which set Client@running to false and returned false up to https://github.com/cloudamqp/avalanchemq/blob/14e6a82c7d687ee7cfd9f0ae067e1a57f4a2e064/src/avalanchemq/queue/queue.cr#L362 This caused us to end up in a tight loop at https://github.com/cloudamqp/avalanchemq/blob/14e6a82c7d687ee7cfd9f0ae067e1a57f4a2e064/src/avalanchemq/queue/queue.cr#L274-L297 where the current Fiber kept hogging on to the CPU.

Calling Fiber#yield at client#deliver in the case of an IO::Error will allow the read_loop fiber to handle the error in it's fiber and subsequently clean up the lost connection. https://github.com/cloudamqp/avalanchemq/blob/14e6a82c7d687ee7cfd9f0ae067e1a57f4a2e064/src/avalanchemq/client/client.cr#L165-L176  https://github.com/cloudamqp/avalanchemq/blob/14e6a82c7d687ee7cfd9f0ae067e1a57f4a2e064/src/avalanchemq/client/client.cr#L417-L426

May fix the issue observed in #271 