### PR TITLE
Fix Crystal install.sh arguments for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           wget https://crystal-lang.org/install.sh
           chmod +x install.sh
-          sudo ./install.sh --crystal=1.0.0
+          sudo ./install.sh --version=1.0
 
       - name: Shards install
         run: shards install --ignore-crystal-version
@@ -68,7 +68,7 @@ jobs:
         run: |
           wget https://crystal-lang.org/install.sh
           chmod +x install.sh
-          sudo ./install.sh --crystal=1.0.0
+          sudo ./install.sh --version=1.0
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           curl -fsSLO https://crystal-lang.org/install.sh
           chmod +x install.sh
-          ./install.sh --crystal=1.0.0
+          ./install.sh --version=1.0
 
       - name: Install dependencies
         run: |

--- a/build/rpm-with-docker
+++ b/build/rpm-with-docker
@@ -4,7 +4,7 @@ docker run --rm -it -v "$PWD":/work:Z "$image" /bin/sh -c "
 set -eux
 curl -fsSLO https://crystal-lang.org/install.sh
 chmod +x install.sh
-./install.sh --crystal=1.0.0
+./install.sh --version=1.0
 yum install dnf-plugins-core
 yum config-manager --set-enabled PowerTools
 yum install -y git rpmlint rpm-build openssl-devel zlib-devel help2man systemd-devel


### PR DESCRIPTION
* --version replaces --crystal
* Packages are named by major.minor, e.g. 1.0 is the latest patch
  release of 1.0 (1.0.0)

https://crystal-lang.org/2021/08/13/install-specific-versions.html