### PR TITLE
Display the timestamp of the first & last message in a Queue.

### DIFF
--- a/src/avalanchemq/queue/ready.cr
+++ b/src/avalanchemq/queue/ready.cr
@@ -158,6 +158,10 @@ module AvalancheMQ
         @ready[0]?
       end
 
+      def last?
+        @ready.last?
+      end
+
       def [](idx)
         @ready[idx]
       end

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -74,6 +74,12 @@
     }
   }
 
+  function formatTimestamp(timestamp) {
+    const date = new Date(timestamp).toISOString().split("T");
+
+    return `${date[0]} ${date[1].split(".")[0]}`;
+  }
+
   /**
   * @param datalistID id of the datalist element linked to input
   * @param type input content, accepts: queues, exchanges, vhosts, users
@@ -101,7 +107,8 @@
       duration,
       argumentHelper,
       argumentHelperJSON,
-      autoCompleteDatalist
+      autoCompleteDatalist,
+      formatTimestamp
     }
   })
 })()

--- a/static/queue.html
+++ b/static/queue.html
@@ -69,6 +69,16 @@
             <td id="q-unacked"></td>
             <td id="q-unacked-bytes"></td>
           </tr>
+          <tr>
+            <th>Timestamps</th>
+            <th>First</th>
+            <th>Last</th>
+          </tr>
+          <tr>
+            <td></td>
+            <td id="q-first-timestamp"> - </td>
+            <td id="q-last-timestamp"> - </td>
+          </tr>
         </table>
       </section>
       <section class="card cols-4">
@@ -345,6 +355,13 @@
           document.getElementById('q-ready').textContent = avalanchemq.helpers.formatNumber(item.ready)
           document.getElementById('q-ready-bytes').textContent = avalanchemq.helpers.nFormatter(item.ready_bytes) + 'B'
           document.getElementById('q-consumers').textContent = avalanchemq.helpers.formatNumber(item.consumers)
+          if (item.first_message_timestamp !== undefined && item.first_message_timestamp !== 0) {
+            document.getElementById('q-first-timestamp').textContent = avalanchemq.helpers.formatTimestamp(item.first_message_timestamp)
+            document.getElementById('q-last-timestamp').textContent = avalanchemq.helpers.formatTimestamp(item.last_message_timestamp)
+          } else {
+            document.getElementById('q-first-timestamp').textContent = " - "
+            document.getElementById('q-last-timestamp').textContent = " - "
+          }
           consumersTable.updateTable(item.consumer_details)
           if (all) {
             let features = ''


### PR DESCRIPTION
By displaying the timestamp, it's easier to observe if the consumer is lagging behind.

![image](https://user-images.githubusercontent.com/9164583/132481487-dbcf0f43-1fd8-40de-99a8-6b5e5612e7a5.png)


closes #250