### PR TITLE
Fix GC loop exit bug

### DIFF
--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -749,11 +749,10 @@ module AvalancheMQ
           GC.collect
         end
         @dirty = false
-      rescue ex
-        @log.fatal("Unhandled exception in #gc_segments_loop, " \
-                   "killing process #{ex.inspect_with_backtrace}")
       end
-    ensure
+    rescue ex
+      @log.fatal("Unhandled exception in #gc_segments_loop, " \
+                  "killing process #{ex.inspect_with_backtrace}")
       exit 1
     end
 


### PR DESCRIPTION
Should only exit if there's an unhandled exception