### PR TITLE
Allow Get/Reject from paused queue via the API

### DIFF
--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -125,7 +125,6 @@ describe AvalancheMQ::Queue do
         response = post("/api/queues/%2f/#{q_name}/get", body: body)
         response.status_code.should eq 200
         body = JSON.parse(response.body)
-        pp body
         body.size.should eq 1
         # can get from UI/API even though queue is paused
         body[0]["payload"].should eq "test message 2"

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -104,7 +104,7 @@ describe AvalancheMQ::Queue do
       s.vhosts["/"].delete_exchange(x_name)
     end
 
-    it "should be able to get messages from paused queue with force flag", focus: true do
+    it "should be able to get messages from paused queue with force flag" do
       with_channel do |ch|
         x = ch.exchange(x_name, "direct")
         q = ch.queue(q_name)

--- a/spec/queue_spec.cr
+++ b/spec/queue_spec.cr
@@ -103,5 +103,40 @@ describe AvalancheMQ::Queue do
       s.vhosts["/"].delete_queue(q_name)
       s.vhosts["/"].delete_exchange(x_name)
     end
+
+    it "should be able to get messages from paused queue with force flag", focus: true do
+      with_channel do |ch|
+        x = ch.exchange(x_name, "direct")
+        q = ch.queue(q_name)
+        q.bind(x.name, q.name)
+        x.publish_confirm "test message", q.name
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message")
+
+        iq = s.vhosts["/"].exchanges[x_name].queue_bindings[{q.name, nil}].first
+        iq.pause!
+
+        x.publish_confirm "test message 2", q.name
+        x.publish_confirm "test message 3", q.name
+
+        # cannot get from client, queue is paused
+        q.get(no_ack: true).should be_nil
+
+        body = %({ "count": 1, "ack_mode": "get", "encoding": "auto" })
+        response = post("/api/queues/%2f/#{q_name}/get", body: body)
+        response.status_code.should eq 200
+        body = JSON.parse(response.body)
+        pp body
+        body.size.should eq 1
+        # can get from UI/API even though queue is paused
+        body[0]["payload"].should eq "test message 2"
+
+        # resume queue and consume next msg
+        iq.resume!
+        q.get(no_ack: true).try(&.body_io.to_s).should eq("test message 3")
+      end
+    ensure
+      s.vhosts["/"].delete_queue(q_name)
+      s.vhosts["/"].delete_exchange(x_name)
+    end
   end
 end

--- a/src/avalanchemq/http/controller/queues.cr
+++ b/src/avalanchemq/http/controller/queues.cr
@@ -143,7 +143,7 @@ module AvalancheMQ
             if q.internal?
               bad_request(context, "Not allowed to get from internal queue")
             end
-            if q.state != QueueState::Running
+            if q.state != QueueState::Running && q.state != QueueState::Paused
               forbidden(context, "Can't get from queue that is not in running state")
             end
             body = parse_body(context)
@@ -158,7 +158,7 @@ module AvalancheMQ
               j.array do
                 sps = Array(SegmentPosition).new(get_count)
                 get_count.times do
-                  env = q.basic_get(false)
+                  env = q.basic_get(false, true)
                   break if env.nil?
                   sps << env.segment_position
                   size = truncate.nil? ? env.message.size : Math.min(truncate, env.message.size)

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -681,7 +681,7 @@ module AvalancheMQ
     end
 
     def basic_get(no_ack, force = false) : Envelope?
-      return nil unless @state.running? || @state.paused? && force
+      return nil if !@state.running? && (@state.paused? && !force)
       @last_get_time = Time.monotonic
       @get_count += 1
       if env = get(no_ack)

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -680,8 +680,8 @@ module AvalancheMQ
       true
     end
 
-    def basic_get(no_ack) : Envelope?
-      return nil unless @state.running?
+    def basic_get(no_ack, force = false) : Envelope?
+      return nil unless @state.running? || @state.paused? && force
       @last_get_time = Time.monotonic
       @get_count += 1
       if env = get(no_ack)


### PR DESCRIPTION
This allows the workflow of pausing all the consumers and pick the messages in the queue without the
need of stopping any clients

Fixes #293