### PR TITLE
Add GC metrics and queue length to prometheus output

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -29,7 +29,7 @@ describe AvalancheMQ::HTTP::ConsumersController do
     end
   end
 
-  describe "GET /metrics" do
+  describe "GET /metrics/detailed" do
     it "should support specifying families" do
       response = get("/metrics/detailed?family=connection_churn_metrics")
       response.status_code.should eq 200

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -1,0 +1,37 @@
+require "../spec_helper"
+
+describe AvalancheMQ::HTTP::ConsumersController do
+  describe "GET /metrics" do
+    it "should return metrics in prometheus style" do
+      response = get("/metrics")
+      response.status_code.should eq 200
+      response.body.lines.any? do |line|
+        line.starts_with? "telemetry_scrape_duration_seconds"
+      end.should eq true
+    end
+
+    it "should support specifying prefix" do
+      prefix = "testing"
+      response = get("/metrics?prefix=#{prefix}")
+      lines = response.body.lines
+      metric_lines = lines.reject { |l| l.starts_with? "#" }
+      prefix_lines = lines.select { |l| l.starts_with? prefix }
+      telemetry_lines = lines.select { |l| l.starts_with? "telemetry" }
+      prefix_lines.size.should eq metric_lines.size - 2
+      telemetry_lines.size.should eq 2
+    end
+
+    it "should not support a prefix longer than 20" do
+      prefix = "abcdefghijklmnopqrstuvwxyz"
+      response = get("/metrics?prefix=#{prefix}")
+      response.status_code.should eq 400
+      response.body.should eq "{\"error\":\"bad_request\",\"reason\":\"prefix to long\"}"
+    end
+  end
+
+  describe "GET /metrics" do
+    it "should support specifying families" do
+      fail "TODO!"
+    end
+  end
+end

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -14,9 +14,9 @@ describe AvalancheMQ::HTTP::ConsumersController do
       prefix = "testing"
       response = get("/metrics?prefix=#{prefix}")
       lines = response.body.lines
-      metric_lines = lines.reject { |l| l.starts_with? "#" }
-      prefix_lines = lines.select { |l| l.starts_with? prefix }
-      telemetry_lines = lines.select { |l| l.starts_with? "telemetry" }
+      metric_lines = lines.reject(&.starts_with? "#")
+      prefix_lines = lines.select(&.starts_with? prefix)
+      telemetry_lines = lines.select(&.starts_with? "telemetry")
       prefix_lines.size.should eq metric_lines.size - 2
       telemetry_lines.size.should eq 2
     end

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -31,7 +31,15 @@ describe AvalancheMQ::HTTP::ConsumersController do
 
   describe "GET /metrics" do
     it "should support specifying families" do
-      fail "TODO!"
+      response = get("/metrics/detailed?family=connection_churn_metrics")
+      response.status_code.should eq 200
+      lines = response.body.lines
+      lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_true
+
+      response = get("/metrics/detailed?family=family=queue_coarse_metrics")
+      response.status_code.should eq 200
+      lines = response.body.lines
+      lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_false
     end
   end
 end

--- a/src/avalanchemq/http/controller/prometheus.cr
+++ b/src/avalanchemq/http/controller/prometheus.cr
@@ -54,7 +54,7 @@ module AvalancheMQ
           context
         end
 
-        get "/metrics/detailed" do |context, params|
+        get "/metrics/detailed" do |context, _|
           prefix = context.request.query_params["prefix"]? || "lavinmq"
           bad_request(context, "prefix to long") if prefix.size > 20
           families = context.request.query_params.fetch_all("family")

--- a/src/avalanchemq/http/controller/prometheus.cr
+++ b/src/avalanchemq/http/controller/prometheus.cr
@@ -158,19 +158,6 @@ module AvalancheMQ
                       value: @amqp_server.disk_free,
                       type: "gauge",
                       help: "Disk space available in bytes"})
-        # writer.write({name: "alarms_file_descriptor_limit", value: 0})
-        # writer.write({name: "alarms_free_disk_space_watermark", value: 0, type: "counter"})
-        # writer.write({name: "alarms_memory_used_watermark", value: 0})
-        # writer.write({name: "io_read_ops_total", value: 0, type: "counter", help: "Total number of I/O read operations"})
-        # writer.write({name: "io_read_bytes_total", value: 0, type: "counter", help: "Total number of I/O bytes read"})
-        # writer.write({name: "io_write_ops_total", value: 0, type: "counter", help: "Total number of I/O write operations"})
-        # writer.write({name: "io_write_bytes_total", value: 0, type: "counter", help: "Total number of I/O bytes written"})
-        # writer.write({name: "io_sync_ops_total", value: 0, type: "counter", help: "Total number of I/O sync operations"})
-        # writer.write({name: "io_seek_ops_total", value: 0, type: "counter", help: "Total number of I/O seek operations"})
-        # writer.write({name: "io_open_attempt_ops_total", value: 0, type: "counter", help: "Total number of file open attempts"})
-        # writer.write({name: "io_reopen_ops_total", value: 0, type: "counter", help: "Total number of times files have been reopened"})
-        # writer.write({name: "io_read_time_seconds_total", value: 0, type: "counter", help: "Total I/O read time"})
-        # writer.write({name: "io_write_time_seconds_total", value: 0, type: "counter", help: "Total I/O write time"})
       end
 
       private def overview_queue_metrics(u, writer)
@@ -214,26 +201,6 @@ module AvalancheMQ
                        value: ready + unacked,
                        type: "gauge",
                        help: "Sum of ready and unacknowledged messages - total queue depth"})
-        # writer.write({name: "queue_messages_persistent", value: 0, type: "gauge", help: "Persistent messages"})
-        # writer.write({name: "queue_messages_bytes", value: 0, type: "gauge", help: "Size in bytes of ready and unacknowledged messages"})
-        # writer.write({name: "queue_messages_ready_bytes", value: 0, type: "gauge", help: "Size in bytes of ready messages"})
-        # writer.write({name: "queue_messages_unacked_bytes", value: 0, type: "gauge", help: "Size in bytes of all unacknowledged messages"})
-        # writer.write({name: "channel_messages_unacked", value: 0, type: "gauge", help: "Delivered but not yet acknowledged messages"})
-        # writer.write({name: "channel_messages_unconfirmed", value: 0, type: "gauge", help: "Published but not yet confirmed messages"})
-        # writer.write({name: "channel_messages_published_total", value: 0, type: "counter", help: ""})
-        # writer.write({name: "channel_messages_confirmed_total", value: 0, type: "counter", help: "Total number of messages published into an exchange and confirmed on the channel"})
-        # writer.write({name: "channel_messages_unroutable_returned_total", value: 0, type: "counter", help: "Total number of messages published as mandatory into an exchange and returned to the publisher as unroutable"})
-        # writer.write({name: "channel_messages_unroutable_dropped_total", value: 0, type: "counter", help: "Total number of messages published as non-mandatory into an exchange and dropped as unroutable"})
-        # writer.write({name: "channel_get_ack_total", value: 0, type: "counter", help: "Total number of messages fetched with basic.get in manual acknowledgement mode"})
-        # writer.write({name: "channel_get_total", value: 0, type: "counter", help: "Total number of messages fetched with basic.get in automatic acknowledgement mode"})
-        # writer.write({name: "channel_messages_delivered_ack_total", value: 0, type: "counter", help: "Total number of messages delivered to consumers in manual acknowledgement mode"})
-        # writer.write({name: "channel_messages_delivered_total", value: 0, type: "counter", help: "Total number of messages delivered to consumers in automatic acknowledgement mode"})
-        # writer.write({name: "channel_messages_redelivered_total", value: 0, type: "counter", help: "Total number of messages redelivered to consumers"})
-        # writer.write({name: "channel_messages_acked_total", value: 0, type: "counter", help: "Total number of messages acknowledged by consumers"})
-        # writer.write({name: "channel_get_empty_total", value: 0, type: "counter", help: "Total number of times basic.get operations fetched no message"})
-        # writer.write({name: "connection_incoming_bytes_total", value: 0, type: "counter", help: "Total number of bytes received on a connection"})
-        # writer.write({name: "connection_outgoing_bytes_total", value: 0, type: "counter", help: "Total number of bytes sent on a connection"})
-        # writer.write({name: "queue_messages_published_total", value: 0, type: "gauge", help: "Total number of messages published to queues"})
       end
 
       private def custom_metrics(u, writer)

--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -22,7 +22,7 @@ module AvalancheMQ
 
     getter name, exchanges, queues, log, data_dir, policies, parameters,
       log, shovels, direct_reply_channels, default_user,
-      connections, dir
+      connections, dir, gc_runs, gc_timing
     property? flow = true
     property? dirty = false
     getter? closed = false
@@ -40,6 +40,8 @@ module AvalancheMQ
     @fsync = false
     @connections = Array(Client).new(512)
     @segments : Hash(UInt32, MFile)
+    @gc_runs = 0
+    @gc_timing = Hash(String, Float64).new { |h,k| h[k] = 0 }
 
     def initialize(@name : String, @server_data_dir : String,
                    @log : Logger, @default_user : User, @events : Server::Event)
@@ -751,6 +753,7 @@ module AvalancheMQ
           GC.collect
         end
         @dirty = false
+        @gc_runs += 1
       end
     rescue ex
       @log.fatal("Unhandled exception in #gc_segments_loop, " \
@@ -763,6 +766,7 @@ module AvalancheMQ
         mem = Benchmark.memory(&blk)
         @log.info { "GC segments, #{desc} used #{mem.humanize_bytes} memory" }
       end
+      @gc_timing[desc] += elapsed.total_milliseconds
       return if elapsed.total_milliseconds <= 10
       @log.info { "GC segments, #{desc} took #{elapsed.total_milliseconds} ms" }
     end


### PR DESCRIPTION
Number or GC runs since start and total time for each part of the GC

Output: 

```
...
avalanchemq_vhost_gc_runs{name="/"} 2
avalanchemq_vhost_gc_time_collecting_sps{name="/"} 0.239276
avalanchemq_vhost_gc_time_garbage_collecting{name="/"} 0.078221
avalanchemq_vhost_gc_time_compact_internal_queues{name="/"} 0.039041
avalanchemq_vhost_gc_time_gc_collect{name="/"} 4.5320160000000005
...
avalanchemq_queue_messages_ready{name="asd", vhost="/"} 77
avalanchemq_queue_messages_unacked{name="asd", vhost="/"} 0
...
```

Inspiration: https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/metrics-detailed.md