### PR TITLE
rm 2GB limit on mfile

### DIFF
--- a/src/avalanchemq/message.cr
+++ b/src/avalanchemq/message.cr
@@ -33,7 +33,7 @@ module AvalancheMQ
       rk = AMQP::ShortString.from_io io, format
       pr = AMQP::Properties.from_io io, format
       sz = UInt64.from_io io, format
-      body = io.to_slice[io.pos, sz]
+      body = io.to_slice(io.pos, sz)
       BytesMessage.new(ts, ex, rk, pr, sz, body)
     end
   end

--- a/src/avalanchemq/mfile.cr
+++ b/src/avalanchemq/mfile.cr
@@ -173,6 +173,10 @@ class MFile < IO
     @buffer
   end
 
+  def to_slice(pos, size)
+    (@buffer + pos).to_slice(size)
+  end
+
   def punch_hole(size : UInt32, offset : UInt32 = 0u32) : UInt32
     {% if flag?(:linux) %}
       return 0u32 if size < PAGESIZE

--- a/src/avalanchemq/mfile.cr
+++ b/src/avalanchemq/mfile.cr
@@ -20,10 +20,10 @@ end
 # not `size` large, only on graceful close is the file truncated to its `size`.
 # The file does not expand further than initial `capacity`, unless manually expanded.
 class MFile < IO
-  property pos = 0
+  property pos = 0i64
   getter? closed = false
-  getter size = 0
-  getter capacity = 0
+  getter size = 0i64
+  getter capacity = 0i64
   getter path : String
   @buffer : Pointer(UInt8)
   @fd : Int32
@@ -35,7 +35,7 @@ class MFile < IO
     @readonly = capacity.nil?
     @fd = open_fd
     @size = file_size
-    @capacity = capacity ? Math.max(capacity.to_i32, @size) : @size
+    @capacity = capacity ? Math.max(capacity.to_i64, @size) : @size
     if @capacity > @size
       code = LibC.ftruncate(@fd, @capacity)
       raise File::Error.from_errno("Error truncating file", file: @path) if code < 0
@@ -66,16 +66,16 @@ class MFile < IO
     fd
   end
 
-  private def file_size : Int32
+  private def file_size : Int64
     code = LibC.fstat(@fd, out stat)
     raise File::Error.from_errno("Unable to get info", file: @path) if code < 0
-    stat.st_size.to_i32
+    stat.st_size.to_i64
   end
 
-  def disk_usage : UInt64
+  def disk_usage : Int64
     code = LibC.fstat(@fd, out stat)
     raise File::Error.from_errno("Unable to get info", file: @path) if code < 0
-    stat.st_blocks.to_u64 * 512
+    stat.st_blocks.to_i64 * 512
   end
 
   private def mmap : Pointer(UInt8)
@@ -142,7 +142,7 @@ class MFile < IO
     raise IO::EOFError.new if pos + slice.size > @capacity
     slice.copy_to(@buffer + pos, slice.size)
     @pos = pos += slice.size
-    @size = pos if pos > @size
+    @size = pos.to_i64 if pos > @size
   end
 
   def read(slice : Bytes)
@@ -177,10 +177,10 @@ class MFile < IO
     (@buffer + pos).to_slice(size)
   end
 
-  def punch_hole(size : UInt32, offset : UInt32 = 0u32) : UInt32
+  def punch_hole(size : Int, offset : Int = 0i64) : Int64
     {% if flag?(:linux) %}
-      return 0u32 if size < PAGESIZE
-      o = offset
+      return 0i64 if size < PAGESIZE
+      o = offset.to_i64
 
       # page align offset
       offset = page_align(offset)
@@ -193,15 +193,15 @@ class MFile < IO
         size = page_align(size)
         size -= PAGESIZE
       end
-      return 0u32 if size == 0
+      return 0i64 if size == 0
 
       addr = @buffer + offset
       if LibC.madvise(addr, size, LibC::MADV_REMOVE) != 0
         raise IO::Error.from_errno("madvise")
       end
-      size
+      size.to_i64
     {% else %}
-      return 0u32 # only linux supports MADV_REMOVE/hole punching
+      return 0i64 # only linux supports MADV_REMOVE/hole punching
     {% end %}
   end
 
@@ -219,10 +219,10 @@ class MFile < IO
     DontNeed
   end
 
-  def truncate(new_size : Int) : Int32
-    new_size = page_align(new_size.to_i32)
+  def truncate(new_size : Int) : Int64
+    new_size = page_align(new_size.to_i64)
     bytes = @capacity - new_size
-    return 0 if bytes < PAGESIZE # don't bother truncating less than a page
+    return 0i64 if bytes < PAGESIZE # don't bother truncating less than a page
     munmap(@buffer + new_size, bytes)
     @capacity = @size = new_size
     code = LibC.ftruncate(@fd, new_size)
@@ -231,7 +231,7 @@ class MFile < IO
   end
 
   def resize(new_size : Int) : Nil
-    capacity = new_size.to_i32
+    capacity = new_size.to_i64
 
     # resize the file first
     code = LibC.ftruncate(@fd, capacity)
@@ -239,7 +239,7 @@ class MFile < IO
 
     {% if flag?(:linux) %}
       # then remap
-      buffer = LibC.mremap(@buffer, @capacity, capacity.to_i32, LibC::MREMAP_MAYMOVE).as(UInt8*)
+      buffer = LibC.mremap(@buffer, @capacity, capacity.to_i64, LibC::MREMAP_MAYMOVE).as(UInt8*)
       raise RuntimeError.from_errno("mremap") if buffer == LibC::MAP_FAILED
       @capacity = capacity
       @buffer = buffer

--- a/src/avalanchemq/queue/durable_queue.cr
+++ b/src/avalanchemq/queue/durable_queue.cr
@@ -154,7 +154,7 @@ module AvalancheMQ
       @ack.fsync
     end
 
-    SP_SIZE = SegmentPosition::BYTESIZE
+    SP_SIZE = SegmentPosition::BYTESIZE.to_i64
 
     private def restore_index : Nil
       @log.info "Restoring index"

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -487,7 +487,7 @@ module AvalancheMQ
       return @segment_file if @segment_id == id
       mfile = @vhost.segment_file(id)
       @segment_id = id
-      @segment_file = IO::Memory.new(mfile.to_slice, writeable: false)
+      @segment_file = IO::Memory.new(mfile.to_unsafe, mfile.capacity, writeable: false)
     end
 
     def metadata(sp) : MessageMetadata?

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -481,13 +481,13 @@ module AvalancheMQ
     end
 
     @segment_id = 0_u32
-    @segment_file = IO::Memory.new(0)
+    @segment_file : MFile?
 
-    private def segment_file(id : UInt32) : IO::Memory
-      return @segment_file if @segment_id == id
+    private def segment_file(id : UInt32) : MFile
+      return @segment_file.not_nil! if @segment_id == id
       mfile = @vhost.segment_file(id)
       @segment_id = id
-      @segment_file = IO::Memory.new(mfile.to_unsafe, mfile.capacity, writeable: false)
+      @segment_file = mfile
     end
 
     def metadata(sp) : MessageMetadata?

--- a/src/stdlib/io_memory.cr
+++ b/src/stdlib/io_memory.cr
@@ -2,14 +2,4 @@ class IO::Memory
   def capacity
     @capacity
   end
-
-  # Constructor that takes a Pointer
-  def initialize(buffer : Pointer(UInt8), count : Int, writeable = true)
-    @buffer = buffer
-    @bytesize = @capacity = count.to_i
-    @pos = 0
-    @closed = false
-    @resizeable = false
-    @writeable = writeable
-  end
 end

--- a/src/stdlib/io_memory.cr
+++ b/src/stdlib/io_memory.cr
@@ -2,4 +2,14 @@ class IO::Memory
   def capacity
     @capacity
   end
+
+  # Constructor that takes a Pointer
+  def initialize(buffer : Pointer(UInt8), count : Int, writeable = true)
+    @buffer = buffer
+    @bytesize = @capacity = count.to_i
+    @pos = 0
+    @closed = false
+    @resizeable = false
+    @writeable = writeable
+  end
 end


### PR DESCRIPTION
No need for a Slice/Bytes, use a Pointer instead. Just had to add a
constructor to IO::Memory that took a Pointer as well.