### PR TITLE
Option to set max count for how many messages to purge

### DIFF
--- a/src/avalanchemq/http/controller/queues.cr
+++ b/src/avalanchemq/http/controller/queues.cr
@@ -127,7 +127,15 @@ module AvalancheMQ
             unless user.can_read?(vhost, q.name)
               access_refused(context, "User doesn't have permissions to read queue '#{q.name}'")
             end
-            q.purge
+            count = context.request.query_params["count"]? || ""
+            if count.empty?
+              q.purge
+            else
+              count_i = count.to_i?
+              bad_request(context, "Count must be a number") if count_i.nil?
+              bad_request(context, "Count must be greater than 0") if count_i <= 0
+              q.purge(count_i)
+            end
             context.response.status_code = 204
           end
         end

--- a/src/avalanchemq/queue/queue.cr
+++ b/src/avalanchemq/queue/queue.cr
@@ -834,11 +834,19 @@ module AvalancheMQ
       end
     end
 
-    def purge : UInt32
-      count = @ready.purge
-      @log.debug { "Purged #{count} messages" }
+    def purge(max_count : Int? = nil) : UInt32
+      @log.info "Purging"
+      delete_count = if max_count.nil?
+                       @ready.purge
+                     else
+                       Math.min(max_count, @ready.size)
+                         .times
+                         .compact_map { |_| @ready.shift? }
+                         .size
+                     end
+      @log.debug { "Purged #{delete_count} messages" }
       @vhost.trigger_gc!
-      count.to_u32
+      delete_count.to_u32
     end
 
     def match?(frame)

--- a/static/queue.html
+++ b/static/queue.html
@@ -249,13 +249,16 @@
         </form>
         <p> Pausing a queue will stop deliveries to all consumers. </p>
       </section>
+      <form method="delete" id="purgeQueue" class="form card cols-3">
+        <h3>Purge queue</h3>
+        <label>
+          <span>Number of messages</span>
+          <input type="count" name="count" placeholder="All">
+        </label>
+        <button type="submit" class="btn-danger">Purge queue</button>
+      </form>
       <section class="card cols-3">
-        <h3>Danger zone</h3>
-        <form method="delete" id="purgeQueue" class="form">
-          <label>
-            <button type="submit" class="btn-danger">Purge queue</button>
-          </label>
-        </form>
+        <h3>Delete queue</h3>
         <form method="delete" id="deleteQueue" class="form">
           <label>
             <button type="submit" class="btn-danger">Delete queue</button>


### PR DESCRIPTION
Allows the user to purge X number of messages instead of usign "Get message" feature to remove the
from the queue which is slow if there are a lot of messages to be dropped.

Fixes #295