### PR TITLE
RockyLinux 8.5 instead of CentOS 8 for RPM build

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['centos:8']
+        os: ['rockylinux:8.5']
     runs-on: ubuntu-20.04
     container: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
CentOS 8 has reach EOL

Fixes #319 