### PR TITLE
Use the statically linked libgc from the crystal container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN redoc-cli bundle openapi/openapi.yaml
 
 # Build objects file on build platform for speed
 FROM --platform=$BUILDPLATFORM 84codes/crystal:1.3.2-debian-11 AS builder
-RUN apt-get update && apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/*
+RUN apt-get update && apt-get install -y make curl
 WORKDIR /tmp
 COPY Makefile shard.yml shard.lock .
 RUN make js lib
@@ -21,11 +20,8 @@ ARG TARGETARCH
 RUN make objects target=$TARGETARCH-unknown-linux-gnu -j2
 
 # Link object files on target platform
-FROM debian:11-slim as target-builder
+FROM 84codes/crystal:1.3.2-debian-11 AS target-builder
 WORKDIR /tmp
-RUN apt-get update && \
-    apt-get install -y make gcc libc-dev libpcre3-dev libevent-dev libssl-dev zlib1g-dev libgc-dev && \
-    rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/*
 COPY Makefile .
 COPY --from=builder /tmp/bin bin
 RUN make all -j && rm bin/*.*
@@ -33,7 +29,7 @@ RUN make all -j && rm bin/*.*
 # Resulting image with minimal layers
 FROM debian:11-slim
 RUN apt-get update && \
-    apt-get install -y libssl1.1 libgc1 libevent-2.1-7 && \
+    apt-get install -y libssl1.1 libevent-2.1-7 && \
     rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/*
 COPY --from=target-builder /tmp/bin/* /usr/bin/
 EXPOSE 5672 15672


### PR DESCRIPTION
It's way faster, less GC pauses, noticable when accepting a high rate of
connections.