### PR TITLE
Only allow administrators to get system information

### DIFF
--- a/src/avalanchemq/http/controller/nodes.cr
+++ b/src/avalanchemq/http/controller/nodes.cr
@@ -56,11 +56,13 @@ module AvalancheMQ
 
       private def register_routes
         get "/api/nodes" do |context, _params|
+          refuse_unless_administrator(context, user(context))
           nodes_info.to_json(context.response)
           context
         end
 
         get "/api/nodes/:name" do |context, params|
+          refuse_unless_administrator(context, user(context))
           node = nodes_info.find { |n| n[:name] == params["name"] }
           context.response.status_code = 404 unless node
           node.to_json(context.response) if node


### PR DESCRIPTION
For cases where you dont want to expose the underlying system information to all users that has
access to the broker.
Page is still available but no data will be shown.