### PR TITLE
Rates per vhost

### DIFF
--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -32,6 +32,7 @@ describe AvalancheMQ::HTTP::ConsumersController do
       response = get("/metrics/detailed?family=connection_churn_metrics")
       response.status_code.should eq 200
       lines = response.body.lines
+      pp lines
       lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_true
 
       response = get("/metrics/detailed?family=family=queue_coarse_metrics")

--- a/spec/api/prometheus_spec.cr
+++ b/spec/api/prometheus_spec.cr
@@ -32,7 +32,6 @@ describe AvalancheMQ::HTTP::ConsumersController do
       response = get("/metrics/detailed?family=connection_churn_metrics")
       response.status_code.should eq 200
       lines = response.body.lines
-      pp lines
       lines.any?(&.starts_with? "lavinmq_detailed_connections_opened_total").should be_true
 
       response = get("/metrics/detailed?family=family=queue_coarse_metrics")

--- a/src/avalanchemq/client/amqp_connection.cr
+++ b/src/avalanchemq/client/amqp_connection.cr
@@ -1,6 +1,6 @@
 module AvalancheMQ
   module AMQPConnection
-    def self.start(socket, connection_info, vhosts, users, events)
+    def self.start(socket, connection_info, vhosts, users)
       remote_address = connection_info.src
       log = Log.for "AMQPConnection[address=#{remote_address}]"
       socket.read_timeout = 15
@@ -10,7 +10,7 @@ module AvalancheMQ
             if tune_ok = tune(socket, log)
               if vhost = open(socket, vhosts, user, log)
                 socket.read_timeout = heartbeat_timeout(tune_ok)
-                Client.new(socket, connection_info, vhost, user, events, tune_ok, start_ok)
+                Client.new(socket, connection_info, vhost, user, tune_ok, start_ok)
               end
             end
           end

--- a/src/avalanchemq/client/channel.cr
+++ b/src/avalanchemq/client/channel.cr
@@ -39,10 +39,10 @@ module AvalancheMQ
       rate_stats(%w(ack get publish deliver redeliver reject confirm return_unroutable))
       property deliver_count, redeliver_count
 
-      def initialize(@client : Client, @id : UInt16, @events : Server::Event)
+      def initialize(@client : Client, @id : UInt16)
         @log = Log.for "channel[client=#{@client.remote_address} id=#{@id}]"
         @name = "#{@client.channel_name_prefix}[#{@id}]"
-        @events.send(EventType::ChannelCreated)
+        @client.vhost.events.send(EventType::ChannelCreated)
         @next_msg_body_tmp = IO::Memory.new
       end
 
@@ -191,7 +191,7 @@ module AvalancheMQ
 
       private def finish_publish(body_io, ts)
         @publish_count += 1
-        @events.send(EventType::ClientPublish)
+        @client.vhost.events.send(EventType::ClientPublish)
         props = @next_msg_props.not_nil!
         props.timestamp ||= ts if Config.instance.set_timestamp
         msg = Message.new(ts.to_unix * 1000,
@@ -242,7 +242,7 @@ module AvalancheMQ
 
       def confirm_nack(multiple = false)
         return unless @confirm
-        @events.send(EventType::ClientPublishConfirm)
+        @client.vhost.events.send(EventType::ClientPublishConfirm)
         @confirm_count += 1 # Stats
         send AMQP::Frame::Basic::Nack.new(@id, @confirm_total, multiple, requeue: false)
       end
@@ -263,7 +263,7 @@ module AvalancheMQ
 
       def confirm_ack(multiple = false)
         return unless @confirm
-        @events.send(EventType::ClientPublishConfirm)
+        @client.vhost.events.send(EventType::ClientPublishConfirm)
         @confirm_count += 1 # Stats
         send AMQP::Frame::Basic::Ack.new(@id, @confirm_total, multiple)
       end
@@ -297,10 +297,10 @@ module AvalancheMQ
         @client.deliver(frame, msg) || return false
         if redelivered
           @redeliver_count += 1
-          @events.send(EventType::ClientRedeliver)
+          @client.vhost.events.send(EventType::ClientRedeliver)
         else
           @deliver_count += 1
-          @events.send(EventType::ClientDeliver)
+          @client.vhost.events.send(EventType::ClientDeliver)
         end
         true
       end
@@ -369,7 +369,7 @@ module AvalancheMQ
             @client.send_access_refused(frame, "Queue '#{frame.queue}' in vhost '#{@client.vhost.name}' is internal")
           else
             @get_count += 1
-            @events.send(EventType::ClientGet)
+            @client.vhost.events.send(EventType::ClientGet)
             q.basic_get(frame.no_ack) do |env|
               persistent = env.message.properties.delivery_mode == 2_u8
               delivery_tag = next_delivery_tag(q, env.segment_position,
@@ -460,7 +460,7 @@ module AvalancheMQ
           c.ack(unack.sp)
         end
         unack.queue.ack(unack.sp)
-        @events.send(EventType::ClientAck)
+        @client.vhost.events.send(EventType::ClientAck)
         @ack_count += 1
       end
 
@@ -501,7 +501,7 @@ module AvalancheMQ
         end
         unack.queue.reject(unack.sp, requeue)
         @reject_count += 1
-        @events.send(EventType::ClientReject)
+        @client.vhost.events.send(EventType::ClientReject)
       end
 
       def basic_qos(frame) : Nil
@@ -542,7 +542,7 @@ module AvalancheMQ
           unack.queue.reject(unack.sp, true)
         end
         @next_msg_body_file.try &.close
-        @events.send(EventType::ChannelClosed)
+        @client.vhost.events.send(EventType::ChannelClosed)
         @log.debug { "Closed" }
       end
 

--- a/src/avalanchemq/client/channel.cr
+++ b/src/avalanchemq/client/channel.cr
@@ -42,7 +42,7 @@ module AvalancheMQ
       def initialize(@client : Client, @id : UInt16)
         @log = Log.for "channel[client=#{@client.remote_address} id=#{@id}]"
         @name = "#{@client.channel_name_prefix}[#{@id}]"
-        @client.vhost.events.send(EventType::ChannelCreated)
+        @client.vhost.event_tick(EventType::ChannelCreated)
         @next_msg_body_tmp = IO::Memory.new
       end
 
@@ -191,7 +191,7 @@ module AvalancheMQ
 
       private def finish_publish(body_io, ts)
         @publish_count += 1
-        @client.vhost.events.send(EventType::ClientPublish)
+        @client.vhost.event_tick(EventType::ClientPublish)
         props = @next_msg_props.not_nil!
         props.timestamp ||= ts if Config.instance.set_timestamp
         msg = Message.new(ts.to_unix * 1000,
@@ -242,7 +242,7 @@ module AvalancheMQ
 
       def confirm_nack(multiple = false)
         return unless @confirm
-        @client.vhost.events.send(EventType::ClientPublishConfirm)
+        @client.vhost.event_tick(EventType::ClientPublishConfirm)
         @confirm_count += 1 # Stats
         send AMQP::Frame::Basic::Nack.new(@id, @confirm_total, multiple, requeue: false)
       end
@@ -263,7 +263,7 @@ module AvalancheMQ
 
       def confirm_ack(multiple = false)
         return unless @confirm
-        @client.vhost.events.send(EventType::ClientPublishConfirm)
+        @client.vhost.event_tick(EventType::ClientPublishConfirm)
         @confirm_count += 1 # Stats
         send AMQP::Frame::Basic::Ack.new(@id, @confirm_total, multiple)
       end
@@ -297,10 +297,10 @@ module AvalancheMQ
         @client.deliver(frame, msg) || return false
         if redelivered
           @redeliver_count += 1
-          @client.vhost.events.send(EventType::ClientRedeliver)
+          @client.vhost.event_tick(EventType::ClientRedeliver)
         else
           @deliver_count += 1
-          @client.vhost.events.send(EventType::ClientDeliver)
+          @client.vhost.event_tick(EventType::ClientDeliver)
         end
         true
       end
@@ -369,7 +369,7 @@ module AvalancheMQ
             @client.send_access_refused(frame, "Queue '#{frame.queue}' in vhost '#{@client.vhost.name}' is internal")
           else
             @get_count += 1
-            @client.vhost.events.send(EventType::ClientGet)
+            @client.vhost.event_tick(EventType::ClientGet)
             q.basic_get(frame.no_ack) do |env|
               persistent = env.message.properties.delivery_mode == 2_u8
               delivery_tag = next_delivery_tag(q, env.segment_position,
@@ -460,7 +460,7 @@ module AvalancheMQ
           c.ack(unack.sp)
         end
         unack.queue.ack(unack.sp)
-        @client.vhost.events.send(EventType::ClientAck)
+        @client.vhost.event_tick(EventType::ClientAck)
         @ack_count += 1
       end
 
@@ -501,7 +501,7 @@ module AvalancheMQ
         end
         unack.queue.reject(unack.sp, requeue)
         @reject_count += 1
-        @client.vhost.events.send(EventType::ClientReject)
+        @client.vhost.event_tick(EventType::ClientReject)
       end
 
       def basic_qos(frame) : Nil
@@ -542,7 +542,7 @@ module AvalancheMQ
           unack.queue.reject(unack.sp, true)
         end
         @next_msg_body_file.try &.close
-        @client.vhost.events.send(EventType::ChannelClosed)
+        @client.vhost.event_tick(EventType::ChannelClosed)
         @log.debug { "Closed" }
       end
 

--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -419,7 +419,7 @@ module AvalancheMQ
       @exclusive_queues.clear
       @channels.each_value &.close
       @channels.clear
-      @vhost.events.send(EventType::ConnectionClosed) unless @vhost.events.closed?
+      @vhost.event_tick(EventType::ConnectionClosed)
       @on_close_callback.try &.call(self)
       @on_close_callback = nil
     end

--- a/src/avalanchemq/client/client.cr
+++ b/src/avalanchemq/client/client.cr
@@ -42,7 +42,6 @@ module AvalancheMQ
                    @connection_info : ConnectionInfo,
                    @vhost : VHost,
                    @user : User,
-                   @events : Server::Event,
                    tune_ok,
                    start_ok)
       @remote_address = @connection_info.src
@@ -63,7 +62,6 @@ module AvalancheMQ
       @channels = Hash(UInt16, Client::Channel).new
       @exclusive_queues = Array(Queue).new
       @vhost.add_connection(self)
-      @events.send(EventType::ConnectionCreated)
       @log.info { "Connection established for user=#{@user.name}" }
       spawn read_loop, name: "Client#read_loop #{@remote_address}"
     end
@@ -303,8 +301,8 @@ module AvalancheMQ
       !@running ? "closed" : (@vhost.flow? ? "running" : "flow")
     end
 
-    def self.start(socket, conn_props, vhosts, users, events)
-      AMQPConnection.start(socket, conn_props, vhosts, users, events)
+    def self.start(socket, conn_props, vhosts, users)
+      AMQPConnection.start(socket, conn_props, vhosts, users)
     end
 
     private def with_channel(frame)
@@ -337,7 +335,7 @@ module AvalancheMQ
     end
 
     private def open_channel(frame)
-      @channels[frame.channel] = Client::Channel.new(self, frame.channel, @events)
+      @channels[frame.channel] = Client::Channel.new(self, frame.channel)
       send AMQP::Frame::Channel::OpenOk.new(frame.channel)
     end
 
@@ -421,7 +419,7 @@ module AvalancheMQ
       @exclusive_queues.clear
       @channels.each_value &.close
       @channels.clear
-      @events.send(EventType::ConnectionClosed) unless @events.closed?
+      @vhost.events.send(EventType::ConnectionClosed) unless @vhost.events.closed?
       @on_close_callback.try &.call(self)
       @on_close_callback = nil
     end

--- a/src/avalanchemq/http/controller/main.cr
+++ b/src/avalanchemq/http/controller/main.cr
@@ -63,12 +63,12 @@ module AvalancheMQ
             end
           end
 
-          details = @amqp_server.stats_details
-          {% for name in OVERVIEW_STATS %}
-            {{name.id}}_count = details[:{{name.id}}]
-            {{name.id}}_rate = details[:{{name.id}}_details][:rate]
-            add_logs!({{name.id}}_log, details[:{{name.id}}_details][:log])
-          {% end %}
+          # details = @amqp_server.stats_details
+          # {% for name in OVERVIEW_STATS %}
+          #   {{name.id}}_count = details[:{{name.id}}]
+          #   {{name.id}}_rate = details[:{{name.id}}_details][:rate]
+          #   add_logs!({{name.id}}_log, details[:{{name.id}}_details][:log])
+          # {% end %}
 
           {
             avalanchemq_version: AvalancheMQ::VERSION,

--- a/src/avalanchemq/http/controller/main.cr
+++ b/src/avalanchemq/http/controller/main.cr
@@ -61,15 +61,12 @@ module AvalancheMQ
               add_logs!(ready_log, q.message_count_log)
               add_logs!(unacked_log, q.unacked_count_log)
             end
+            {% for sm in OVERVIEW_STATS %}
+              {{sm.id}}_count += vhost.stats_details[:{{sm.id}}]
+              {{sm.id}}_rate += vhost.stats_details[:{{sm.id}}_details][:rate]
+              add_logs!({{sm.id}}_log, vhost.stats_details[:{{sm.id}}_details][:log])
+            {% end %}
           end
-
-          # details = @amqp_server.stats_details
-          # {% for name in OVERVIEW_STATS %}
-          #   {{name.id}}_count = details[:{{name.id}}]
-          #   {{name.id}}_rate = details[:{{name.id}}_details][:rate]
-          #   add_logs!({{name.id}}_log, details[:{{name.id}}_details][:log])
-          # {% end %}
-
           {
             avalanchemq_version: AvalancheMQ::VERSION,
             node:                System.hostname,

--- a/src/avalanchemq/http/controller/nodes.cr
+++ b/src/avalanchemq/http/controller/nodes.cr
@@ -5,7 +5,6 @@ module AvalancheMQ
     class NodesController < Controller
       include StatsHelpers
 
-      # channel_closed channel_created connection_closed connection_created queue_declared queue_deleted
       SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,
                         :queue_declared, :queue_deleted}
 

--- a/src/avalanchemq/http/controller/nodes.cr
+++ b/src/avalanchemq/http/controller/nodes.cr
@@ -21,38 +21,17 @@ module AvalancheMQ
             add_logs!({{sm.id}}_log, vhost.stats_details[:{{sm.id}}_details][:log])
           {% end %}
         end
+        {% begin %}
         {
-          connection_created:         {{ SERVER_METRICS[0].id }},
-          connection_created_details: {
-            rate: {{ SERVER_METRICS[0].id + "_rate" }},
-            log:  {{ SERVER_METRICS[0].id + "_log" }},
-          },
-          connection_closed:         {{ SERVER_METRICS[1].id }},
-          connection_closed_details: {
-            rate: {{ SERVER_METRICS[1].id + "_rate" }},
-            log:  {{ SERVER_METRICS[1].id + "_log" }},
-          },
-          channel_created:         {{ SERVER_METRICS[2].id }},
-          channel_created_details: {
-            rate: {{ SERVER_METRICS[2].id + "_rate" }},
-            log:  {{ SERVER_METRICS[2].id + "_log" }},
-          },
-          channel_closed:         {{ SERVER_METRICS[3].id }},
-          channel_closed_details: {
-            rate: {{ SERVER_METRICS[3].id + "_rate" }},
-            log:  {{ SERVER_METRICS[3].id + "_log" }},
-          },
-          queue_declared:         {{ SERVER_METRICS[4].id }},
-          queue_declared_details: {
-            rate: {{ SERVER_METRICS[4].id + "_rate" }},
-            log:  {{ SERVER_METRICS[4].id + "_log" }},
-          },
-          queue_deleted:         {{ SERVER_METRICS[5].id }},
-          queue_deleted_details: {
-            rate: {{ SERVER_METRICS[5].id + "_rate" }},
-            log:  {{ SERVER_METRICS[5].id + "_log" }},
-          },
+          {% for sm in SERVER_METRICS %}
+            {{sm.id}}: {{sm.id}},
+            {{sm.id}}_details: {
+              rate: {{sm.id}}_rate,
+              log: {{sm.id}}_log,
+            },
+          {% end %}
         }
+        {% end %}
       end
 
       private def general_stats

--- a/src/avalanchemq/http/controller/nodes.cr
+++ b/src/avalanchemq/http/controller/nodes.cr
@@ -91,7 +91,7 @@ module AvalancheMQ
         end
 
         get "/api/nodes/:name" do |context, params|
-          if params[:name] == System.hostname
+          if params["name"] == System.hostname
             stats(context).to_json(context.response)
           else
             context.response.status_code = 404

--- a/src/avalanchemq/http/controller/nodes.cr
+++ b/src/avalanchemq/http/controller/nodes.cr
@@ -3,67 +3,124 @@ require "../controller"
 module AvalancheMQ
   module HTTP
     class NodesController < Controller
-      private def nodes_info
-        Tuple.new({
-          uptime:                     @amqp_server.uptime.total_milliseconds.to_i64,
-          running:                    true,
-          os_pid:                     Process.pid.to_s,
-          fd_total:                   System.file_descriptor_limit[0],
-          fd_used:                    System.file_descriptor_count,
-          processors:                 System.cpu_count,
-          mem_limit:                  @amqp_server.mem_limit,
-          mem_used:                   @amqp_server.rss,
-          mem_used_details:           {log: @amqp_server.rss_log},
-          io_write_count:             @amqp_server.blocks_out,
-          io_write_details:           {log: @amqp_server.blocks_out_log},
-          io_read_count:              @amqp_server.blocks_in,
-          io_read_details:            {log: @amqp_server.blocks_in_log},
-          cpu_user_time:              @amqp_server.user_time,
-          cpu_user_details:           {log: @amqp_server.user_time_log},
-          cpu_sys_time:               @amqp_server.sys_time,
-          cpu_sys_details:            {log: @amqp_server.sys_time_log},
-          db_dir:                     @amqp_server.data_dir,
-          name:                       System.hostname,
-          disk_total:                 @amqp_server.disk_total,
-          disk_total_details:         {log: @amqp_server.disk_total_log},
-          disk_free:                  @amqp_server.disk_free,
-          disk_free_details:          {log: @amqp_server.disk_free_log},
-          connection_created:         @amqp_server.connection_created_count,
-          connection_created_details: {rate: @amqp_server.connection_created_rate,
-                                       log: @amqp_server.connection_created_log},
-          connection_closed:         @amqp_server.connection_closed_count,
-          connection_closed_details: {rate: @amqp_server.connection_closed_rate,
-                                      log: @amqp_server.connection_closed_log},
-          channel_created:         @amqp_server.channel_created_count,
-          channel_created_details: {rate: @amqp_server.channel_created_rate,
-                                    log: @amqp_server.channel_created_log},
-          channel_closed:         @amqp_server.channel_closed_count,
-          channel_closed_details: {rate: @amqp_server.channel_closed_rate,
-                                   log: @amqp_server.channel_closed_log},
-          queue_declared:         @amqp_server.queue_declared_count,
-          queue_declared_details: {rate: @amqp_server.queue_declared_rate,
-                                   log: @amqp_server.queue_declared_log},
-          queue_deleted:         @amqp_server.queue_deleted_count,
-          queue_deleted_details: {rate: @amqp_server.queue_deleted_rate,
-                                  log: @amqp_server.queue_deleted_log},
-          applications: APPLICATIONS,
-          partitions:   Tuple.new,
-          proc_used:    0,
-          run_queue:    0,
-          sockets_used: @amqp_server.vhosts.sum { |_, v| v.connections.size },
-        })
+      include StatsHelpers
+
+      # channel_closed channel_created connection_closed connection_created queue_declared queue_deleted
+      SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,
+                        :queue_declared, :queue_deleted}
+
+      private def vhost_stats
+        {% for sm in SERVER_METRICS %}
+          {{sm.id}} = 0_u64
+          {{sm.id}}_rate = 0_f64
+          {{sm.id}}_log = Deque(Float64).new
+        {% end %}
+
+        @amqp_server.vhosts.each_value do |vhost|
+          {% for sm in SERVER_METRICS %}
+            # connection_created += vhost.stats_details[:connection_created]
+            {{sm.id}} += vhost.stats_details[:{{sm.id}}]
+            {{sm.id}}_rate += vhost.stats_details[:{{sm.id}}_details][:rate]
+            add_logs!({{sm.id}}_log, vhost.stats_details[:{{sm.id}}_details][:log])
+          {% end %}
+        end
+
+        # NamedTuple.new(
+        #   {% for sm in SERVER_METRICS %}
+        #   {{sm.id}}: {{sm}},
+        #   {{sm.id}}_details: {
+        #     rate: {{sm.id}}_rate,
+        #     log: {{sm.id}}_log
+        #   }
+        #   {% end %}
+        # )
+        NamedTuple.new
+
+        # connection_created_details: {
+        #   rate: connection_created_rate,
+        # log: connection_created_log,
+        # },
+        # connection_closed:         @amqp_server.connection_closed_count,
+        # connection_closed_details: {
+        #   rate: @amqp_server.connection_closed_rate,
+        #   # log:  @amqp_server.connection_closed_log,
+        # },
+        # channel_created:         @amqp_server.channel_created_count,
+        # channel_created_details: {
+        #   rate: @amqp_server.channel_created_rate,
+        #   # log:  @amqp_server.channel_created_log,
+        # },
+        # channel_closed:         @amqp_server.channel_closed_count,
+        # channel_closed_details: {
+        #   rate: @amqp_server.channel_closed_rate,
+        #   # log:  @amqp_server.channel_closed_log,
+        # },
+        # queue_declared:         @amqp_server.queue_declared_count,
+        # queue_declared_details: {
+        #   rate: @amqp_server.queue_declared_rate,
+        #   # log:  @amqp_server.queue_declared_log,
+        # },
+        # queue_deleted:         @amqp_server.queue_deleted_count,
+        # queue_deleted_details: {
+        #   rate: @amqp_server.queue_deleted_rate,
+        #   # log:  @amqp_server.queue_deleted_log,
+        # }
+
+      end
+
+      private def general_stats
+        {
+          uptime:  @amqp_server.uptime.total_milliseconds.to_i64,
+          running: true,
+          name:    System.hostname,
+
+        }
+      end
+
+      private def node_stats
+        {
+          os_pid:             Process.pid.to_s,
+          fd_total:           System.file_descriptor_limit[0],
+          fd_used:            System.file_descriptor_count,
+          processors:         System.cpu_count,
+          mem_limit:          @amqp_server.mem_limit,
+          mem_used:           @amqp_server.rss,
+          mem_used_details:   {log: @amqp_server.rss_log},
+          io_write_count:     @amqp_server.blocks_out,
+          io_write_details:   {log: @amqp_server.blocks_out_log},
+          io_read_count:      @amqp_server.blocks_in,
+          io_read_details:    {log: @amqp_server.blocks_in_log},
+          cpu_user_time:      @amqp_server.user_time,
+          cpu_user_details:   {log: @amqp_server.user_time_log},
+          cpu_sys_time:       @amqp_server.sys_time,
+          cpu_sys_details:    {log: @amqp_server.sys_time_log},
+          db_dir:             @amqp_server.data_dir,
+          disk_total:         @amqp_server.disk_total,
+          disk_total_details: {log: @amqp_server.disk_total_log},
+          disk_free:          @amqp_server.disk_free,
+          disk_free_details:  {log: @amqp_server.disk_free_log},
+          applications:       APPLICATIONS,
+          partitions:         Tuple.new,
+          proc_used:          Fiber.count,
+          run_queue:          0,
+          sockets_used:       @amqp_server.vhosts.sum { |_, v| v.connections.size },
+        }
       end
 
       private def register_routes
         get "/api/nodes" do |context, _params|
-          nodes_info.to_json(context.response)
+          stats = general_stats + node_stats + vhost_stats
+          Tuple.new(stats).to_json(context.response)
           context
         end
 
         get "/api/nodes/:name" do |context, params|
-          node = nodes_info.find { |n| n[:name] == params["name"] }
-          context.response.status_code = 404 unless node
-          node.to_json(context.response) if node
+          if params[:name] == System.hostname
+            stats = general_stats + node_stats + vhost_stats
+            stats.to_json(context.response)
+          else
+            context.response.status_code = 404
+          end
           context
         end
       end

--- a/src/avalanchemq/http/controller/prometheus.cr
+++ b/src/avalanchemq/http/controller/prometheus.cr
@@ -116,30 +116,30 @@ module AvalancheMQ
                         "#{writer.prefix}_version" => AvalancheMQ::VERSION,
                         "#{writer.prefix}_cluster" => System.hostname,
                       }})
-        writer.write({name:  "connections_opened_total",
-                      value: @amqp_server.connection_created_count,
-                      type:  "counter",
-                      help:  "Total number of connections opened"})
-        writer.write({name:  "connections_closed_total",
-                      value: @amqp_server.connection_closed_count,
-                      type:  "counter",
-                      help:  "Total number of connections closed or terminated"})
-        writer.write({name:  "channels_opened_total",
-                      value: @amqp_server.channel_created_count,
-                      type:  "counter",
-                      help:  "Total number of channels opened"})
-        writer.write({name:  "channels_closed_total",
-                      value: @amqp_server.channel_closed_count,
-                      type:  "counter",
-                      help:  "Total number of channels closed"})
-        writer.write({name:  "queues_declared_total",
-                      value: @amqp_server.queue_declared_count,
-                      type:  "counter",
-                      help:  "Total number of queues declared"})
-        writer.write({name:  "queues_deleted_total",
-                      value: @amqp_server.queue_deleted_count,
-                      type:  "counter",
-                      help:  "Total number of queues deleted"})
+        # writer.write({name:  "connections_opened_total",
+        #               value: @amqp_server.connection_created_count,
+        #               type:  "counter",
+        #               help:  "Total number of connections opened"})
+        # writer.write({name:  "connections_closed_total",
+        #               value: @amqp_server.connection_closed_count,
+        #               type:  "counter",
+        #               help:  "Total number of connections closed or terminated"})
+        # writer.write({name:  "channels_opened_total",
+        #               value: @amqp_server.channel_created_count,
+        #               type:  "counter",
+        #               help:  "Total number of channels opened"})
+        # writer.write({name:  "channels_closed_total",
+        #               value: @amqp_server.channel_closed_count,
+        #               type:  "counter",
+        #               help:  "Total number of channels closed"})
+        # writer.write({name:  "queues_declared_total",
+        #               value: @amqp_server.queue_declared_count,
+        #               type:  "counter",
+        #               help:  "Total number of queues declared"})
+        # writer.write({name:  "queues_deleted_total",
+        #               value: @amqp_server.queue_deleted_count,
+        #               type:  "counter",
+        #               help:  "Total number of queues deleted"})
         writer.write({name:  "process_open_fds",
                       value: System.file_descriptor_count,
                       type:  "gauge",
@@ -240,30 +240,30 @@ module AvalancheMQ
       end
 
       private def detailed_connection_churn_metrics(writer)
-        writer.write({name:  "detailed_connections_opened_total",
-                      value: @amqp_server.connection_created_count,
-                      type:  "counter",
-                      help:  "Total number of connections opened"})
-        writer.write({name:  "detailed_connections_closed_total",
-                      value: @amqp_server.connection_closed_count,
-                      type:  "counter",
-                      help:  "Total number of connections closed or terminated"})
-        writer.write({name:  "detailed_channels_opened_total",
-                      value: @amqp_server.channel_created_count,
-                      type:  "counter",
-                      help:  "Total number of channels opened"})
-        writer.write({name:  "detailed_channels_closed_total",
-                      value: @amqp_server.channel_closed_count,
-                      type:  "counter",
-                      help:  "Total number of channels closed"})
-        writer.write({name:  "detailed_queues_declared_total",
-                      value: @amqp_server.queue_declared_count,
-                      type:  "counter",
-                      help:  "Total number of queues declared"})
-        writer.write({name:  "detailed_queues_deleted_total",
-                      value: @amqp_server.queue_deleted_count,
-                      type:  "counter",
-                      help:  "Total number of queues deleted"})
+        # writer.write({name:  "detailed_connections_opened_total",
+        #               value: @amqp_server.connection_created_count,
+        #               type:  "counter",
+        #               help:  "Total number of connections opened"})
+        # writer.write({name:  "detailed_connections_closed_total",
+        #               value: @amqp_server.connection_closed_count,
+        #               type:  "counter",
+        #               help:  "Total number of connections closed or terminated"})
+        # writer.write({name:  "detailed_channels_opened_total",
+        #               value: @amqp_server.channel_created_count,
+        #               type:  "counter",
+        #               help:  "Total number of channels opened"})
+        # writer.write({name:  "detailed_channels_closed_total",
+        #               value: @amqp_server.channel_closed_count,
+        #               type:  "counter",
+        #               help:  "Total number of channels closed"})
+        # writer.write({name:  "detailed_queues_declared_total",
+        #               value: @amqp_server.queue_declared_count,
+        #               type:  "counter",
+        #               help:  "Total number of queues declared"})
+        # writer.write({name:  "detailed_queues_deleted_total",
+        #               value: @amqp_server.queue_deleted_count,
+        #               type:  "counter",
+        #               help:  "Total number of queues deleted"})
       end
 
       private def detailed_queue_coarse_metrics(vhosts, writer)

--- a/src/avalanchemq/http/controller/prometheus.cr
+++ b/src/avalanchemq/http/controller/prometheus.cr
@@ -126,7 +126,7 @@ module AvalancheMQ
                       }})
 
         writer.write({name:  "connections_opened_total",
-                      value: stats[:connection_opened],
+                      value: stats[:connection_created],
                       type:  "counter",
                       help:  "Total number of connections opened"})
         writer.write({name:  "connections_closed_total",
@@ -260,20 +260,19 @@ module AvalancheMQ
             {{sm.id}} += vhost.stats_details[:{{sm.id}}]
           {% end %}
         end
+        {% begin %}
         {
-          connection_opened: {{ SERVER_METRICS[0].id }},
-          connection_closed: {{ SERVER_METRICS[1].id }},
-          channel_created:   {{ SERVER_METRICS[2].id }},
-          channel_closed:    {{ SERVER_METRICS[3].id }},
-          queue_declared:    {{ SERVER_METRICS[4].id }},
-          queue_deleted:     {{ SERVER_METRICS[5].id }},
+          {% for sm in SERVER_METRICS %}
+            {{sm.id}}: {{sm.id}},
+          {% end %}
         }
+        {% end %}
       end
 
       private def detailed_connection_churn_metrics(vhosts, writer)
         stats = vhost_stats(vhosts)
         writer.write({name:  "detailed_connections_opened_total",
-                      value: stats[:connection_opened],
+                      value: stats[:connection_created],
                       type:  "counter",
                       help:  "Total number of connections opened"})
         writer.write({name:  "detailed_connections_closed_total",

--- a/src/avalanchemq/server.cr
+++ b/src/avalanchemq/server.cr
@@ -14,32 +14,26 @@ require "./connection_info"
 require "./proxy_protocol"
 require "./client/client"
 require "./stats"
-require "./event_type"
 
 module AvalancheMQ
   class Server
     getter vhosts, users, data_dir, parameters
     getter? closed, flow
-    alias Event = Channel(EventType)
     include ParameterTarget
-    include Stats
-    getter channel_closed_log, channel_created_log, connection_closed_log, connection_created_log,
-      queue_declared_log, queue_deleted_log
+
+    # getter channel_closed_log, channel_created_log, connection_closed_log, connection_created_log,
+    #   queue_declared_log, queue_deleted_log
 
     @start = Time.monotonic
     @closed = false
     @flow = true
-    rate_stats(%w(channel_closed channel_created connection_closed connection_created
-      queue_declared queue_deleted ack deliver get publish confirm redeliver reject))
 
     def initialize(@data_dir : String)
       @log = Log.for "amqpserver"
       Dir.mkdir_p @data_dir
       @listeners = Hash(Socket::Server, Symbol).new # Socket => protocol
       @users = UserStore.instance(@data_dir)
-      @events = Event.new(16384)
-      spawn events_loop, name: "Server#events"
-      @vhosts = VHostStore.new(@data_dir, @users, @events)
+      @vhosts = VHostStore.new(@data_dir, @users)
       @parameters = ParameterStore(Parameter).new(@data_dir, "parameters.json", @log)
       apply_parameter
       spawn stats_loop, name: "Server#stats_loop"
@@ -155,8 +149,6 @@ module AvalancheMQ
       @listeners.each_key &.close
       @log.debug { "Closing vhosts" }
       @vhosts.close
-      @log.debug { "Closing #events channel" }
-      @events.close
     end
 
     def add_parameter(p : Parameter)
@@ -201,7 +193,7 @@ module AvalancheMQ
     end
 
     def handle_connection(socket, connection_info)
-      client = Client.start(socket, connection_info, @vhosts, @users, @events)
+      client = Client.start(socket, connection_info, @vhosts, @users)
     ensure
       socket.close if client.nil?
     end
@@ -245,26 +237,6 @@ module AvalancheMQ
       end
     end
 
-    private def events_loop
-      while type = @events.receive?
-        case type
-        in EventType::ChannelClosed        then @channel_closed_count += 1
-        in EventType::ChannelCreated       then @channel_created_count += 1
-        in EventType::ConnectionClosed     then @connection_closed_count += 1
-        in EventType::ConnectionCreated    then @connection_created_count += 1
-        in EventType::QueueDeclared        then @queue_declared_count += 1
-        in EventType::QueueDeleted         then @queue_deleted_count += 1
-        in EventType::ClientAck            then @ack_count += 1
-        in EventType::ClientDeliver        then @deliver_count += 1
-        in EventType::ClientGet            then @get_count += 1
-        in EventType::ClientPublish        then @publish_count += 1
-        in EventType::ClientPublishConfirm then @confirm_count += 1
-        in EventType::ClientRedeliver      then @redeliver_count += 1
-        in EventType::ClientReject         then @reject_count += 1
-        end
-      end
-    end
-
     def update_stats_rates
       @vhosts.each_value do |vhost|
         vhost.queues.each_value(&.update_rates)
@@ -273,8 +245,8 @@ module AvalancheMQ
           connection.update_rates
           connection.channels.each_value(&.update_rates)
         end
+        vhost.update_rates
       end
-      update_rates()
     end
 
     private def stats_loop

--- a/src/avalanchemq/server.cr
+++ b/src/avalanchemq/server.cr
@@ -21,9 +21,6 @@ module AvalancheMQ
     getter? closed, flow
     include ParameterTarget
 
-    # getter channel_closed_log, channel_created_log, connection_closed_log, connection_created_log,
-    #   queue_declared_log, queue_deleted_log
-
     @start = Time.monotonic
     @closed = false
     @flow = true
@@ -363,13 +360,6 @@ module AvalancheMQ
     getter disk_total_log = Deque(Int64).new(Config.instance.stats_log_size)
     getter disk_free = 0_i64
     getter disk_free_log = Deque(Int64).new(Config.instance.stats_log_size)
-
-    SERVER_METRICS = {:connection_created, :connection_closed, :channel_created, :channel_closed,
-                      :queue_declared, :queue_deleted}
-    {% for sm in SERVER_METRICS %}
-      getter {{sm.id}}_count = 0_u64
-      getter {{sm.id}}_rate = 0_f64
-    {% end %}
 
     private def control_flow!
       if @disk_free < 2_i64 * Config.instance.segment_size

--- a/src/avalanchemq/vhost.cr
+++ b/src/avalanchemq/vhost.cr
@@ -952,6 +952,7 @@ module AvalancheMQ
       trigger_gc!
     end
 
+    # ameba:disable Metrics/CyclomaticComplexity
     private def events_loop
       while type = @events.receive?
         case type

--- a/src/avalanchemq/vhost_store.cr
+++ b/src/avalanchemq/vhost_store.cr
@@ -8,7 +8,7 @@ module AvalancheMQ
     @log = Log.for "vhoststore"
 
     def initialize(@data_dir : String,
-                   @users : UserStore, @events : Server::Event)
+                   @users : UserStore)
       @vhosts = Hash(String, VHost).new
       load!
     end
@@ -25,7 +25,7 @@ module AvalancheMQ
       if v = @vhosts[name]?
         return v
       end
-      vhost = VHost.new(name, @data_dir, user, @events)
+      vhost = VHost.new(name, @data_dir, user)
       @log.info { "vhost=#{name} created" }
       @users.add_permission(user.name, name, /.*/, /.*/, /.*/)
       @users.add_permission(UserStore::DIRECT_USER, name, /.*/, /.*/, /.*/)
@@ -64,7 +64,7 @@ module AvalancheMQ
           JSON.parse(f).as_a.each do |vhost|
             next unless vhost.as_h?
             name = vhost["name"].as_s
-            @vhosts[name] = VHost.new(name, @data_dir, default_user, @events)
+            @vhosts[name] = VHost.new(name, @data_dir, default_user)
             @users.add_permission(UserStore::DIRECT_USER, name, /.*/, /.*/, /.*/)
           end
         rescue JSON::ParseException

--- a/src/stdlib/NamedTuple.cr
+++ b/src/stdlib/NamedTuple.cr
@@ -1,0 +1,5 @@
+struct NamedTuple
+  def +(other : NamedTuple)
+    merge(other)
+  end
+end

--- a/src/stdlib/fiber.cr
+++ b/src/stdlib/fiber.cr
@@ -2,4 +2,10 @@ class Fiber
   def self.list(&blk : Fiber -> Nil)
     fibers.unsafe_each &blk
   end
+
+  def self.count
+    c = 0
+    Fiber.list { |_| c += 1 }
+    c
+  end
 end

--- a/static/nodes.html
+++ b/static/nodes.html
@@ -87,73 +87,10 @@
     <script src="/js/layout.js"></script>
     <script src="/js/dom.js"></script>
     <script src="/js/helpers.js"></script>
-    <script src="/js/nodes.js"></script>
     <script src="/js/vhosts.js"></script>
     <script src="/js/table.js"></script>
     <script src="/js/lib/chart.js"></script>
     <script src="/js/chart.js"></script>
-    <script>
-      /* globals avalanchemq */
-
-      const memoryChart = avalanchemq.chart.render('memoryChart', 'MB', { aspectRatio: 2 })
-      const ioChart = avalanchemq.chart.render('ioChart', 'ops', { aspectRatio: 2 })
-      const cpuChart = avalanchemq.chart.render('cpuChart', '%', { aspectRatio: 2 }, true)
-      const connectionChurnChart = avalanchemq.chart.render('connectionChurnChart', '/s', { aspectRatio: 2 })
-      const channelChurnChart = avalanchemq.chart.render('channelChurnChart', '/s', { aspectRatio: 2 })
-      const queueChurnChart = avalanchemq.chart.render('queueChurnChart', '/s', { aspectRatio: 2 })
-
-      const toMegaBytes = (dataPointInBytes) => (dataPointInBytes / 10 ** 6).toFixed(2)
-
-      function updateCharts (response) {
-        const memoryStats = {
-          mem_used_details: toMegaBytes(response[0].mem_used),
-          mem_used_details_log: response[0].mem_used_details.log.map(toMegaBytes)
-        }
-        avalanchemq.chart.update(memoryChart, memoryStats)
-
-        const ioStats = {
-          io_write_details: response[0].io_write_details.log.slice(-1)[0],
-          io_write_details_log: response[0].io_write_details.log,
-          io_read_details: response[0].io_read_details.log.slice(-1)[0],
-          io_read_details_log: response[0].io_read_details.log
-        }
-        avalanchemq.chart.update(ioChart, ioStats)
-
-
-        const cpuStats = {
-          user_time_details: response[0].cpu_user_details.log.slice(-1)[0] * 100,
-          system_time_details: response[0].cpu_sys_details.log.slice(-1)[0] * 100,
-          user_time_details_log: response[0].cpu_user_details.log.map(x => x * 100),
-          system_time_details_log: response[0].cpu_sys_details.log.map(x => x * 100)
-        }
-        avalanchemq.chart.update(cpuChart, cpuStats, "origin")
-
-        const connectionChurnStats = {
-          connection_created_details: response[0].connection_created_details.rate,
-          connection_closed_details: response[0].connection_closed_details.rate,
-          connection_created_details_log: response[0].connection_created_details.log,
-          connection_closed_details_log: response[0].connection_closed_details.log
-        }
-        avalanchemq.chart.update(connectionChurnChart, connectionChurnStats)
-
-        const channelChurnStats = {
-          channel_created_details: response[0].channel_created_details.rate,
-          channel_closed_details: response[0].channel_closed_details.rate,
-          channel_created_details_log: response[0].channel_created_details.log,
-          channel_closed_details_log: response[0].channel_closed_details.log
-        }
-        avalanchemq.chart.update(channelChurnChart, channelChurnStats)
-
-        const queueChurnStats = {
-          queue_declared_details: response[0].queue_declared_details.rate,
-          queue_deleted_details: response[0].queue_deleted_details.rate,
-          queue_declared_details_log: response[0].queue_declared_details.log,
-          queue_deleted_details_log: response[0].queue_deleted_details.log
-        }
-        avalanchemq.chart.update(queueChurnChart, queueChurnStats)
-
-      }
-      avalanchemq.nodes.start(updateCharts)
-    </script>
+    <script src="/js/nodes.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Moving rate metrics from server to each vhost

Will use some additional memory since we store more data per vhost but it allows us to get show metrics per vhost which is good for limited users. 
This also includes prometheus endpoint where it only shows metrics for the vhosts that the user has access to, additionally the requester can limit which vhost to get the "normal" and the prometheus metrics for using `?vhost=some_vhost` 