### PR TITLE
Show verbose spec output on CI as well

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -34,9 +34,7 @@ BASE_URL       = "http://localhost:#{HTTP_PORT}"
   end
 end
 
-unless ENV["CI"]?
-  Spec.override_default_formatter(Spec::VerboseFormatter.new)
-end
+Spec.override_default_formatter(Spec::VerboseFormatter.new)
 
 Spec.after_each do
   s.vhosts.each_value do |vhost|


### PR DESCRIPTION
IMO there's no point hiding it on the CI, useful to see what it's doing
when debugging runs.